### PR TITLE
DBZ-6962 Initial support for pod templating 

### DIFF
--- a/examples/postgres/010_debezium-server-ephemeral.yml
+++ b/examples/postgres/010_debezium-server-ephemeral.yml
@@ -3,7 +3,7 @@ kind: DebeziumServer
 metadata:
   name: my-debezium
 spec:
-  image: quay.io/debezium/server:2.4.0.Final
+  image: quay.io/debezium/server:nightly
   quarkus:
     config:
       log.console.json: false

--- a/k8/debeziumservers.debezium.io-v1.yml
+++ b/k8/debeziumservers.debezium.io-v1.yml
@@ -689,6 +689,389 @@ spec:
                           type: object
                       type: object
                     type: array
+                  templates:
+                    description: Debezium Server resource templates.
+                    properties:
+                      pod:
+                        description: Pod template.
+                        properties:
+                          affinity:
+                            description: Pod affinity rules
+                            properties:
+                              podAntiAffinity:
+                                properties:
+                                  requiredDuringSchedulingIgnoredDuringExecution:
+                                    items:
+                                      properties:
+                                        namespaces:
+                                          items:
+                                            type: string
+                                          type: array
+                                        topologyKey:
+                                          type: string
+                                        labelSelector:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  operator:
+                                                    type: string
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                          type: object
+                                        namespaceSelector:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  operator:
+                                                    type: string
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                          type: object
+                                      type: object
+                                    type: array
+                                  preferredDuringSchedulingIgnoredDuringExecution:
+                                    items:
+                                      properties:
+                                        podAffinityTerm:
+                                          properties:
+                                            namespaces:
+                                              items:
+                                                type: string
+                                              type: array
+                                            topologyKey:
+                                              type: string
+                                            labelSelector:
+                                              properties:
+                                                matchExpressions:
+                                                  items:
+                                                    properties:
+                                                      key:
+                                                        type: string
+                                                      values:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      operator:
+                                                        type: string
+                                                    type: object
+                                                  type: array
+                                                matchLabels:
+                                                  additionalProperties:
+                                                    type: string
+                                                  type: object
+                                              type: object
+                                            namespaceSelector:
+                                              properties:
+                                                matchExpressions:
+                                                  items:
+                                                    properties:
+                                                      key:
+                                                        type: string
+                                                      values:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      operator:
+                                                        type: string
+                                                    type: object
+                                                  type: array
+                                                matchLabels:
+                                                  additionalProperties:
+                                                    type: string
+                                                  type: object
+                                              type: object
+                                          type: object
+                                        weight:
+                                          type: integer
+                                      type: object
+                                    type: array
+                                type: object
+                              nodeAffinity:
+                                properties:
+                                  preferredDuringSchedulingIgnoredDuringExecution:
+                                    items:
+                                      properties:
+                                        weight:
+                                          type: integer
+                                        preference:
+                                          properties:
+                                            matchFields:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  operator:
+                                                    type: string
+                                                type: object
+                                              type: array
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  operator:
+                                                    type: string
+                                                type: object
+                                              type: array
+                                          type: object
+                                      type: object
+                                    type: array
+                                  requiredDuringSchedulingIgnoredDuringExecution:
+                                    properties:
+                                      nodeSelectorTerms:
+                                        items:
+                                          properties:
+                                            matchFields:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  operator:
+                                                    type: string
+                                                type: object
+                                              type: array
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  operator:
+                                                    type: string
+                                                type: object
+                                              type: array
+                                          type: object
+                                        type: array
+                                    type: object
+                                type: object
+                              podAffinity:
+                                properties:
+                                  requiredDuringSchedulingIgnoredDuringExecution:
+                                    items:
+                                      properties:
+                                        namespaces:
+                                          items:
+                                            type: string
+                                          type: array
+                                        topologyKey:
+                                          type: string
+                                        labelSelector:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  operator:
+                                                    type: string
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                          type: object
+                                        namespaceSelector:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  operator:
+                                                    type: string
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                          type: object
+                                      type: object
+                                    type: array
+                                  preferredDuringSchedulingIgnoredDuringExecution:
+                                    items:
+                                      properties:
+                                        podAffinityTerm:
+                                          properties:
+                                            namespaces:
+                                              items:
+                                                type: string
+                                              type: array
+                                            topologyKey:
+                                              type: string
+                                            labelSelector:
+                                              properties:
+                                                matchExpressions:
+                                                  items:
+                                                    properties:
+                                                      key:
+                                                        type: string
+                                                      values:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      operator:
+                                                        type: string
+                                                    type: object
+                                                  type: array
+                                                matchLabels:
+                                                  additionalProperties:
+                                                    type: string
+                                                  type: object
+                                              type: object
+                                            namespaceSelector:
+                                              properties:
+                                                matchExpressions:
+                                                  items:
+                                                    properties:
+                                                      key:
+                                                        type: string
+                                                      values:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      operator:
+                                                        type: string
+                                                    type: object
+                                                  type: array
+                                                matchLabels:
+                                                  additionalProperties:
+                                                    type: string
+                                                  type: object
+                                              type: object
+                                          type: object
+                                        weight:
+                                          type: integer
+                                      type: object
+                                    type: array
+                                type: object
+                            type: object
+                          metadata:
+                            description: Metadata applied to the resource.
+                            properties:
+                              labels:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                              annotations:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                            type: object
+                          securityContext:
+                            description: Pod-level security attributes and container
+                              settings
+                            properties:
+                              runAsGroup:
+                                type: integer
+                              runAsNonRoot:
+                                type: boolean
+                              windowsOptions:
+                                properties:
+                                  gmsaCredentialSpecName:
+                                    type: string
+                                  hostProcess:
+                                    type: boolean
+                                  gmsaCredentialSpec:
+                                    type: string
+                                  runAsUserName:
+                                    type: string
+                                type: object
+                              sysctls:
+                                items:
+                                  properties:
+                                    value:
+                                      type: string
+                                    name:
+                                      type: string
+                                  type: object
+                                type: array
+                              fsGroupChangePolicy:
+                                type: string
+                              seLinuxOptions:
+                                properties:
+                                  role:
+                                    type: string
+                                  type:
+                                    type: string
+                                  user:
+                                    type: string
+                                  level:
+                                    type: string
+                                type: object
+                              fsGroup:
+                                type: integer
+                              supplementalGroups:
+                                items:
+                                  type: integer
+                                type: array
+                              runAsUser:
+                                type: integer
+                              seccompProfile:
+                                properties:
+                                  type:
+                                    type: string
+                                  localhostProfile:
+                                    type: string
+                                type: object
+                            type: object
+                          imagePullSecrets:
+                            description: List of local references to secrets used
+                              for pulling any of the images used by this Pod.
+                            items:
+                              properties:
+                                name:
+                                  type: string
+                              type: object
+                            type: array
+                        type: object
+                    type: object
                 type: object
               transforms:
                 items:

--- a/k8/debeziumservers.debezium.io-v1.yml
+++ b/k8/debeziumservers.debezium.io-v1.yml
@@ -18,8 +18,11 @@ spec:
           spec:
             properties:
               runtime:
+                description: Configuration allowing the modification of various aspects
+                  of Debezium Server runtime.
                 properties:
                   volumes:
+                    description: Additional volumes mounted to containers.
                     items:
                       properties:
                         hostPath:
@@ -669,6 +672,8 @@ spec:
                       type: object
                     type: array
                   env:
+                    description: Additional environment variables set from ConfigMaps
+                      or Secrets in containers.
                     items:
                       properties:
                         prefix:
@@ -1074,13 +1079,21 @@ spec:
                     type: object
                 type: object
               transforms:
+                description: Single Message Transformations employed by this instance
+                  of Debezium Server.
                 items:
                   properties:
                     negate:
+                      description: Determines if the result of the applied predicate
+                        will be negated.
                       type: boolean
                     predicate:
+                      description: The name of the predicate to be applied to this
+                        transformation.
                       type: string
                     type:
+                      description: Fully qualified name of Java class implementing
+                        the transformation.
                       type: string
                     config:
                       properties:
@@ -1094,10 +1107,13 @@ spec:
                   type: object
                 type: array
               sink:
+                description: Sink configuration.
                 properties:
                   type:
+                    description: Sink type recognised by Debezium Server.
                     type: string
                   config:
+                    description: Sink configuration properties.
                     properties:
                       props:
                         additionalProperties:
@@ -1108,22 +1124,32 @@ spec:
                     x-kubernetes-preserve-unknown-fields: true
                 type: object
               storage:
+                description: Storage configuration to be used by this instance of
+                  Debezium Server.
                 properties:
                   claimName:
+                    description: Name of persistent volume claim for persistent storage.
                     type: string
                   type:
+                    description: Storage type.
                     enum:
                     - persistent
                     - ephemeral
                     type: string
                 type: object
               version:
+                description: Version of Debezium Server to be used.
                 type: string
               image:
+                description: Image used for Debezium Server container. This property
+                  takes precedence over version.
                 type: string
               quarkus:
+                description: Quarkus configuration passed down to Debezium Server
+                  process.
                 properties:
                   config:
+                    description: Quarkus configuration properties.
                     properties:
                       props:
                         additionalProperties:
@@ -1137,8 +1163,11 @@ spec:
                 additionalProperties:
                   properties:
                     type:
+                      description: Fully qualified name of Java class implementing
+                        the predicate.
                       type: string
                     config:
+                      description: Predicate configuration properties.
                       properties:
                         props:
                           additionalProperties:
@@ -1148,12 +1177,16 @@ spec:
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
                   type: object
+                description: Predicates employed by this instance of Debezium Server.
                 type: object
               source:
+                description: Debezium source connector configuration.
                 properties:
                   class:
+                    description: Fully qualified name of source connector Java class.
                     type: string
                   config:
+                    description: Source connector configuration properties.
                     properties:
                       props:
                         additionalProperties:
@@ -1164,12 +1197,16 @@ spec:
                     x-kubernetes-preserve-unknown-fields: true
                 type: object
               format:
+                description: Message output format configuration.
                 properties:
                   key:
+                    description: Message key format configuration.
                     properties:
                       type:
+                        description: Format type recognised by Debezium Server.
                         type: string
                       config:
+                        description: Format configuration properties.
                         properties:
                           props:
                             additionalProperties:
@@ -1180,10 +1217,13 @@ spec:
                         x-kubernetes-preserve-unknown-fields: true
                     type: object
                   value:
+                    description: Message value format configuration.
                     properties:
                       type:
+                        description: Format type recognised by Debezium Server.
                         type: string
                       config:
+                        description: Format configuration properties.
                         properties:
                           props:
                             additionalProperties:
@@ -1194,10 +1234,13 @@ spec:
                         x-kubernetes-preserve-unknown-fields: true
                     type: object
                   header:
+                    description: Message header format configuration.
                     properties:
                       type:
+                        description: Format type recognised by Debezium Server.
                         type: string
                       config:
+                        description: Format configuration properties.
                         properties:
                           props:
                             additionalProperties:

--- a/k8/kubernetes.yml
+++ b/k8/kubernetes.yml
@@ -179,7 +179,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-          image: quay.io/debezium/operator:2.4.0.Final
+          image: quay.io/debezium/operator:nightly
           imagePullPolicy: Always
           livenessProbe:
             failureThreshold: 3

--- a/src/main/java/io/debezium/operator/model/DebeziumServerSpec.java
+++ b/src/main/java/io/debezium/operator/model/DebeziumServerSpec.java
@@ -8,19 +8,45 @@ package io.debezium.operator.model;
 import java.util.List;
 import java.util.Map;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+
 import io.debezium.operator.config.ConfigMappable;
 import io.debezium.operator.config.ConfigMapping;
 
+@JsonInclude(JsonInclude.Include.NON_DEFAULT)
 public class DebeziumServerSpec implements ConfigMappable {
+
+    @JsonPropertyDescription("Image used for Debezium Server container. This property takes precedence over version.")
     private String image;
+
+    @JsonPropertyDescription("Version of Debezium Server to be used.")
     private String version;
+
+    @JsonPropertyDescription("Storage configuration to be used by this instance of Debezium Server.")
     private Storage storage;
+
+    @JsonPropertyDescription("Sink configuration.")
     private Sink sink;
+
+    @JsonPropertyDescription("Debezium source connector configuration.")
     private Source source;
+
+    @JsonPropertyDescription("Message output format configuration.")
     private Format format;
+
+    @JsonPropertyDescription("Quarkus configuration passed down to Debezium Server process.")
     private Quarkus quarkus;
+
+    @JsonPropertyDescription("Configuration allowing the modification of various aspects of Debezium Server runtime.")
     private Runtime runtime;
+
+    @JsonPropertyDescription("Single Message Transformations employed by this instance of Debezium Server.")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private List<Transformation> transforms;
+
+    @JsonPropertyDescription("Predicates employed by this instance of Debezium Server.")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private Map<String, Predicate> predicates;
 
     public DebeziumServerSpec() {

--- a/src/main/java/io/debezium/operator/model/Format.java
+++ b/src/main/java/io/debezium/operator/model/Format.java
@@ -5,13 +5,20 @@
  */
 package io.debezium.operator.model;
 
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+
 import io.debezium.operator.config.ConfigMappable;
 import io.debezium.operator.config.ConfigMapping;
 
 public class Format implements ConfigMappable {
 
+    @JsonPropertyDescription("Message key format configuration.")
     private FormatType key;
+
+    @JsonPropertyDescription("Message value format configuration.")
     private FormatType value;
+
+    @JsonPropertyDescription("Message header format configuration.")
     private FormatType header;
 
     public Format() {

--- a/src/main/java/io/debezium/operator/model/FormatType.java
+++ b/src/main/java/io/debezium/operator/model/FormatType.java
@@ -5,13 +5,17 @@
  */
 package io.debezium.operator.model;
 
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+
 import io.debezium.operator.config.ConfigMappable;
 import io.debezium.operator.config.ConfigMapping;
 
 public class FormatType implements ConfigMappable {
 
+    @JsonPropertyDescription("Format type recognised by Debezium Server.")
     private String type;
 
+    @JsonPropertyDescription("Format configuration properties.")
     private ConfigProperties config;
 
     public FormatType() {

--- a/src/main/java/io/debezium/operator/model/Predicate.java
+++ b/src/main/java/io/debezium/operator/model/Predicate.java
@@ -5,12 +5,19 @@
  */
 package io.debezium.operator.model;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+
 import io.debezium.operator.config.ConfigMappable;
 import io.debezium.operator.config.ConfigMapping;
 
 public class Predicate implements ConfigMappable {
 
+    @JsonPropertyDescription("Fully qualified name of Java class implementing the predicate.")
+    @JsonProperty(required = true)
     private String type;
+
+    @JsonPropertyDescription("Predicate configuration properties.")
     private ConfigProperties config;
 
     public Predicate() {

--- a/src/main/java/io/debezium/operator/model/Quarkus.java
+++ b/src/main/java/io/debezium/operator/model/Quarkus.java
@@ -5,10 +5,14 @@
  */
 package io.debezium.operator.model;
 
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+
 import io.debezium.operator.config.ConfigMappable;
 import io.debezium.operator.config.ConfigMapping;
 
 public class Quarkus implements ConfigMappable {
+
+    @JsonPropertyDescription("Quarkus configuration properties.")
     private ConfigProperties config;
 
     public Quarkus() {

--- a/src/main/java/io/debezium/operator/model/Runtime.java
+++ b/src/main/java/io/debezium/operator/model/Runtime.java
@@ -15,8 +15,10 @@ import io.fabric8.kubernetes.api.model.Volume;
 
 public class Runtime {
 
+    @JsonPropertyDescription("Additional environment variables set from ConfigMaps or Secrets in containers.")
     private List<EnvFromSource> env;
 
+    @JsonPropertyDescription("Additional volumes mounted to containers.")
     private List<Volume> volumes;
 
     @JsonPropertyDescription("Debezium Server resource templates.")

--- a/src/main/java/io/debezium/operator/model/Runtime.java
+++ b/src/main/java/io/debezium/operator/model/Runtime.java
@@ -8,6 +8,8 @@ package io.debezium.operator.model;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+
 import io.fabric8.kubernetes.api.model.EnvFromSource;
 import io.fabric8.kubernetes.api.model.Volume;
 
@@ -17,9 +19,13 @@ public class Runtime {
 
     private List<Volume> volumes;
 
+    @JsonPropertyDescription("Debezium Server resource templates.")
+    private Templates templates;
+
     public Runtime() {
         this.env = new ArrayList<>();
         this.volumes = new ArrayList<>();
+        this.templates = new Templates();
     }
 
     public List<EnvFromSource> getEnv() {
@@ -36,5 +42,13 @@ public class Runtime {
 
     public void setVolumes(List<Volume> volumes) {
         this.volumes = volumes;
+    }
+
+    public Templates getTemplates() {
+        return templates;
+    }
+
+    public void setTemplates(Templates templates) {
+        this.templates = templates;
     }
 }

--- a/src/main/java/io/debezium/operator/model/Sink.java
+++ b/src/main/java/io/debezium/operator/model/Sink.java
@@ -5,12 +5,19 @@
  */
 package io.debezium.operator.model;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+
 import io.debezium.operator.config.ConfigMappable;
 import io.debezium.operator.config.ConfigMapping;
 
 public class Sink implements ConfigMappable {
 
+    @JsonPropertyDescription("Sink type recognised by Debezium Server.")
+    @JsonProperty(required = true)
     private String type;
+
+    @JsonPropertyDescription("Sink configuration properties.")
     private ConfigProperties config;
 
     public Sink() {

--- a/src/main/java/io/debezium/operator/model/Source.java
+++ b/src/main/java/io/debezium/operator/model/Source.java
@@ -6,20 +6,24 @@
 package io.debezium.operator.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 
 import io.debezium.operator.config.ConfigMappable;
 import io.debezium.operator.config.ConfigMapping;
 
 public class Source implements ConfigMappable {
 
+    @JsonPropertyDescription("Fully qualified name of source connector Java class.")
+    @JsonProperty(value = "class", required = true)
     private String sourceClass;
+
+    @JsonPropertyDescription("Source connector configuration properties.")
     private ConfigProperties config;
 
     public Source() {
         this.config = new ConfigProperties();
     }
 
-    @JsonProperty("class")
     public String getSourceClass() {
         return sourceClass;
     }

--- a/src/main/java/io/debezium/operator/model/Storage.java
+++ b/src/main/java/io/debezium/operator/model/Storage.java
@@ -5,9 +5,14 @@
  */
 package io.debezium.operator.model;
 
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+
 public class Storage {
 
+    @JsonPropertyDescription("Storage type.")
     private StorageType type;
+
+    @JsonPropertyDescription("Name of persistent volume claim for persistent storage.")
     private String claimName;
 
     public Storage() {

--- a/src/main/java/io/debezium/operator/model/Templates.java
+++ b/src/main/java/io/debezium/operator/model/Templates.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.operator.model;
+
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+
+import io.debezium.operator.model.templates.PodTemplate;
+
+public class Templates {
+
+    @JsonPropertyDescription("Pod template.")
+    private PodTemplate pod;
+
+    public Templates() {
+        this.pod = new PodTemplate();
+    }
+
+    public PodTemplate getPod() {
+        return pod;
+    }
+
+    public void setPod(PodTemplate pod) {
+        this.pod = pod;
+    }
+}

--- a/src/main/java/io/debezium/operator/model/Transformation.java
+++ b/src/main/java/io/debezium/operator/model/Transformation.java
@@ -5,13 +5,22 @@
  */
 package io.debezium.operator.model;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+
 import io.debezium.operator.config.ConfigMappable;
 import io.debezium.operator.config.ConfigMapping;
 
 public class Transformation implements ConfigMappable {
 
+    @JsonPropertyDescription("Fully qualified name of Java class implementing the transformation.")
+    @JsonProperty(required = true)
     private String type;
+
+    @JsonPropertyDescription("The name of the predicate to be applied to this transformation.")
     private String predicate;
+
+    @JsonPropertyDescription("Determines if the result of the applied predicate will be negated.")
     private boolean negate = false;
     private ConfigProperties config;
 

--- a/src/main/java/io/debezium/operator/model/templates/HasMetadataTemplate.java
+++ b/src/main/java/io/debezium/operator/model/templates/HasMetadataTemplate.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.operator.model.templates;
+
+/**
+ * Interface for kubernetes objects witch metadata
+ */
+public interface HasMetadataTemplate {
+
+    /**
+     * Gets template metadata
+     *
+     * @return Metadata template
+     */
+    MetadataTemplate getMetadata();
+
+    /**
+     * Sets template metadata
+     *
+     * @param metadata Metadata template
+     */
+    void setMetadata(MetadataTemplate metadata);
+}

--- a/src/main/java/io/debezium/operator/model/templates/MetadataTemplate.java
+++ b/src/main/java/io/debezium/operator/model/templates/MetadataTemplate.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.operator.model.templates;
+
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+@JsonPropertyOrder({ "labels", "annotations" })
+public class MetadataTemplate implements Serializable {
+    public static final long serialVersionUID = 1L;
+
+    private Map<String, String> labels = new HashMap<>(0);
+    private Map<String, String> annotations = new HashMap<>(0);
+
+    public Map<String, String> getLabels() {
+        return labels;
+    }
+
+    public void setLabels(Map<String, String> labels) {
+        this.labels = labels;
+    }
+
+    public Map<String, String> getAnnotations() {
+        return annotations;
+    }
+
+    public void setAnnotations(Map<String, String> annotations) {
+        this.annotations = annotations;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof MetadataTemplate that)) {
+            return false;
+        }
+        return Objects.equals(labels, that.labels) && Objects.equals(annotations, that.annotations);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(labels, annotations);
+    }
+}

--- a/src/main/java/io/debezium/operator/model/templates/PodTemplate.java
+++ b/src/main/java/io/debezium/operator/model/templates/PodTemplate.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.operator.model.templates;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+import io.fabric8.kubernetes.api.model.Affinity;
+import io.fabric8.kubernetes.api.model.LocalObjectReference;
+import io.fabric8.kubernetes.api.model.PodSecurityContext;
+
+@JsonPropertyOrder({ "metadata", "imagePullSecrets", "affinity" })
+@JsonInclude(JsonInclude.Include.NON_DEFAULT)
+public class PodTemplate implements HasMetadataTemplate {
+
+    @JsonPropertyDescription("Metadata applied to the resource.")
+    private MetadataTemplate metadata = new MetadataTemplate();
+
+    @JsonPropertyDescription("List of local references to secrets used for pulling any of the images used by this Pod.")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    private List<LocalObjectReference> imagePullSecrets = List.of();
+
+    @JsonPropertyDescription("Pod affinity rules")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private Affinity affinity;
+
+    @JsonPropertyDescription("Pod-level security attributes and container settings")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private PodSecurityContext securityContext;
+
+    @Override
+    public MetadataTemplate getMetadata() {
+        return metadata;
+    }
+
+    @Override
+    public void setMetadata(MetadataTemplate metadata) {
+        this.metadata = metadata;
+    }
+
+    public List<LocalObjectReference> getImagePullSecrets() {
+        return imagePullSecrets;
+    }
+
+    public void setImagePullSecrets(List<LocalObjectReference> imagePullSecrets) {
+        this.imagePullSecrets = imagePullSecrets;
+    }
+
+    public Affinity getAffinity() {
+        return affinity;
+    }
+
+    public void setAffinity(Affinity affinity) {
+        this.affinity = affinity;
+    }
+
+    public PodSecurityContext getSecurityContext() {
+        return securityContext;
+    }
+
+    public void setSecurityContext(PodSecurityContext securityContext) {
+        this.securityContext = securityContext;
+    }
+}


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-6962

Allows modifying pod creating like this:

```yaml
 runtime:
    templates:
      pod:
        metadata:
          labels:
            foo: bar
        imagePullSecrets:
        -  name: jcechace-pull-secret
 ```
 
Currently the following attributes of pods are supported

- metadata (labels and annotations)
- affinity
- security context
- image pull secrets