### PR TITLE
DBZ-7254 Using quarkiverse QOSDK bom to workaround missing fix in new…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,7 @@
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.version>3.4.3</quarkus.platform.version>
+        <quarkus.operator.sdk.version>6.3.5</quarkus.operator.sdk.version>
 
         <!-- Operator and Image configuration -->
         <quarkus.operator-sdk.crd.validate>false</quarkus.operator-sdk.crd.validate>
@@ -119,9 +120,9 @@
                 </exclusions>
             </dependency>
             <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
+                <groupId>io.quarkiverse.operatorsdk</groupId>
                 <artifactId>quarkus-operator-sdk-bom</artifactId>
-                <version>${quarkus.platform.version}</version>
+                <version>${quarkus.operator.sdk.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
…r QOSDK platform releases

https://issues.redhat.com/browse/DBZ-7254


Since the 2.4 branch is not modularised a separate PR will be opened for that one.