### PR TITLE
DBZ-7448 Consolidated Volume(Mount) and Environment variable management

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,20 +33,22 @@ The snippet bellow provides a rough outline of the `DebeziumServer` spec. See th
 spec:
   version: String
   image: String # exclusive with version
-  storage:
-    type: persistent | ephemeral  # enum
-    claimName: String # only valid and required for "persistent" type
   runtime:
-    env: EnvFromSource array # https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#envfromsource-v1-core
-    volumes: Volume array # https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#volume-v1-core
+    environment:
+      vars:
+        - name: String
+          value: String
+      from: EnvFromSource array # https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#envfromsource-v1-core
+    storage:
+      data:
+        type: persistent | ephemeral  # enum
+        claimName: String # only valid and required for "persistent" type
+      external: Volume array # https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#volume-v1-core
     jmx:
       enabled: boolean
       port: int # defaults to 1099
     templates:
       container:
-        env:
-          - name: String
-            value: String
         resources: # https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#resourcerequirements-v1-core
         securityContext: # https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#securitycontext-v1-core
       pod:

--- a/debezium-operator-api/src/main/java/io/debezium/operator/api/model/DebeziumServerSpec.java
+++ b/debezium-operator-api/src/main/java/io/debezium/operator/api/model/DebeziumServerSpec.java
@@ -10,13 +10,16 @@ import java.util.Map;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
 import io.debezium.operator.api.config.ConfigMappable;
 import io.debezium.operator.api.config.ConfigMapping;
+import io.debezium.operator.api.model.runtime.Runtime;
 import io.debezium.operator.docs.annotations.Documented;
 
 @JsonInclude(JsonInclude.Include.NON_DEFAULT)
 @Documented
+@JsonPropertyOrder({ "image", "version", "image", "quarkus", "runtime", "format", "transforms", "predicates", "source", "sink" })
 public class DebeziumServerSpec implements ConfigMappable {
 
     @JsonPropertyDescription("Image used for Debezium Server container. This property takes precedence over version.")
@@ -25,9 +28,6 @@ public class DebeziumServerSpec implements ConfigMappable {
     @JsonPropertyDescription("Version of Debezium Server to be used.")
     @Documented.Field(defaultValue = "same as operator")
     private String version;
-
-    @JsonPropertyDescription("Storage configuration to be used by this instance of Debezium Server.")
-    private Storage storage;
 
     @JsonPropertyDescription("Sink configuration.")
     private Sink sink;
@@ -53,7 +53,6 @@ public class DebeziumServerSpec implements ConfigMappable {
     private Map<String, Predicate> predicates;
 
     public DebeziumServerSpec() {
-        this.storage = new Storage();
         this.sink = new Sink();
         this.source = new Source();
         this.format = new Format();
@@ -77,14 +76,6 @@ public class DebeziumServerSpec implements ConfigMappable {
 
     public void setVersion(String version) {
         this.version = version;
-    }
-
-    public Storage getStorage() {
-        return storage;
-    }
-
-    public void setStorage(Storage storage) {
-        this.storage = storage;
     }
 
     public Sink getSink() {

--- a/debezium-operator-api/src/main/java/io/debezium/operator/api/model/runtime/Runtime.java
+++ b/debezium-operator-api/src/main/java/io/debezium/operator/api/model/runtime/Runtime.java
@@ -3,26 +3,25 @@
  *
  * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
-package io.debezium.operator.api.model;
-
-import java.util.ArrayList;
-import java.util.List;
+package io.debezium.operator.api.model.runtime;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
+import io.debezium.operator.api.model.runtime.jmx.JmxConfig;
+import io.debezium.operator.api.model.runtime.storage.RuntimeStorage;
+import io.debezium.operator.api.model.runtime.templates.Templates;
 import io.debezium.operator.docs.annotations.Documented;
-import io.fabric8.kubernetes.api.model.EnvFromSource;
-import io.fabric8.kubernetes.api.model.Volume;
 
-@JsonPropertyOrder({ "env", "jmx", "templates", "volumes" })
+@JsonPropertyOrder({ "storage", "environment", "jmx", "templates" })
 @Documented
 public class Runtime {
+    @JsonPropertyDescription("Storage configuration")
+    private RuntimeStorage storage;
 
-    @JsonPropertyDescription("Additional environment variables set from ConfigMaps or Secrets in containers.")
-    @Documented.Field(k8Ref = "envfromsource-v1-core")
-    private List<EnvFromSource> env;
+    @JsonPropertyDescription("Additional environment variables used by this Debezium Server.")
+    private RuntimeEnvironment environment;
 
     @JsonPropertyDescription("JMX configuration.")
     private JmxConfig jmx;
@@ -30,35 +29,15 @@ public class Runtime {
     @JsonPropertyDescription("Debezium Server resource templates.")
     private Templates templates;
 
-    @JsonPropertyDescription("Additional volumes mounted to containers.")
-    @Documented.Field(k8Ref = "volume-v1-core")
-    private List<Volume> volumes;
-
     @JsonPropertyDescription("An existing service account used to run the Debezium Server pod")
     @JsonInclude(JsonInclude.Include.NON_NULL)
     private String serviceAccount;
 
     public Runtime() {
-        this.env = new ArrayList<>();
+        this.storage = new RuntimeStorage();
+        this.environment = new RuntimeEnvironment();
         this.jmx = new JmxConfig();
-        this.volumes = new ArrayList<>();
         this.templates = new Templates();
-    }
-
-    public List<EnvFromSource> getEnv() {
-        return env;
-    }
-
-    public void setEnv(List<EnvFromSource> env) {
-        this.env = env;
-    }
-
-    public List<Volume> getVolumes() {
-        return volumes;
-    }
-
-    public void setVolumes(List<Volume> volumes) {
-        this.volumes = volumes;
     }
 
     public Templates getTemplates() {
@@ -83,5 +62,21 @@ public class Runtime {
 
     public void setServiceAccount(String serviceAccount) {
         this.serviceAccount = serviceAccount;
+    }
+
+    public RuntimeStorage getStorage() {
+        return storage;
+    }
+
+    public void setStorage(RuntimeStorage storage) {
+        this.storage = storage;
+    }
+
+    public RuntimeEnvironment getEnvironment() {
+        return environment;
+    }
+
+    public void setEnvironment(RuntimeEnvironment environment) {
+        this.environment = environment;
     }
 }

--- a/debezium-operator-api/src/main/java/io/debezium/operator/api/model/runtime/RuntimeEnvironment.java
+++ b/debezium-operator-api/src/main/java/io/debezium/operator/api/model/runtime/RuntimeEnvironment.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.operator.api.model.runtime;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+import io.debezium.operator.api.model.runtime.templates.ContainerEnvVar;
+import io.debezium.operator.docs.annotations.Documented;
+import io.fabric8.kubernetes.api.model.EnvFromSource;
+
+@JsonPropertyOrder({ "vars", "from" })
+@Documented
+public class RuntimeEnvironment {
+
+    @JsonPropertyDescription("Environment variables applied to the container.")
+    private List<ContainerEnvVar> vars = List.of();
+
+    @JsonPropertyDescription("Additional environment variables set from ConfigMaps or Secrets in containers.")
+    @Documented.Field(k8Ref = "envfromsource-v1-core")
+    private List<EnvFromSource> from = List.of();
+
+    public List<ContainerEnvVar> getVars() {
+        return vars;
+    }
+
+    public void setVars(List<ContainerEnvVar> vars) {
+        this.vars = vars;
+    }
+
+    public List<EnvFromSource> getFrom() {
+        return from;
+    }
+
+    public void setFrom(List<EnvFromSource> from) {
+        this.from = from;
+    }
+}

--- a/debezium-operator-api/src/main/java/io/debezium/operator/api/model/runtime/jmx/JmxAuthentication.java
+++ b/debezium-operator-api/src/main/java/io/debezium/operator/api/model/runtime/jmx/JmxAuthentication.java
@@ -3,7 +3,7 @@
  *
  * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
-package io.debezium.operator.api.model;
+package io.debezium.operator.api.model.runtime.jmx;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;

--- a/debezium-operator-api/src/main/java/io/debezium/operator/api/model/runtime/jmx/JmxConfig.java
+++ b/debezium-operator-api/src/main/java/io/debezium/operator/api/model/runtime/jmx/JmxConfig.java
@@ -3,7 +3,7 @@
  *
  * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
-package io.debezium.operator.api.model;
+package io.debezium.operator.api.model.runtime.jmx;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;

--- a/debezium-operator-api/src/main/java/io/debezium/operator/api/model/runtime/storage/DataStorage.java
+++ b/debezium-operator-api/src/main/java/io/debezium/operator/api/model/runtime/storage/DataStorage.java
@@ -3,7 +3,7 @@
  *
  * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
-package io.debezium.operator.api.model;
+package io.debezium.operator.api.model.runtime.storage;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
@@ -11,7 +11,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import io.debezium.operator.docs.annotations.Documented;
 
 @Documented
-public class Storage {
+public class DataStorage {
 
     @JsonPropertyDescription("Storage type.")
     @JsonProperty(defaultValue = "ephemeral")
@@ -20,7 +20,7 @@ public class Storage {
     @JsonPropertyDescription("Name of persistent volume claim for persistent storage.")
     private String claimName;
 
-    public Storage() {
+    public DataStorage() {
         this.type = StorageType.EPHEMERAL;
     }
 

--- a/debezium-operator-api/src/main/java/io/debezium/operator/api/model/runtime/storage/RuntimeStorage.java
+++ b/debezium-operator-api/src/main/java/io/debezium/operator/api/model/runtime/storage/RuntimeStorage.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.operator.api.model.runtime.storage;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+import io.debezium.operator.docs.annotations.Documented;
+import io.fabric8.kubernetes.api.model.Volume;
+
+@Documented
+@JsonPropertyOrder({ "data", "external" })
+public class RuntimeStorage {
+
+    @JsonPropertyDescription("File storage configuration used by this instance of Debezium Server.")
+    private DataStorage data = new DataStorage();
+
+    @JsonPropertyDescription("Additional volumes mounted to /debezium/external")
+    @Documented.Field(k8Ref = "volume-v1-core")
+    private List<Volume> external = List.of();
+
+    public DataStorage getData() {
+        return data;
+    }
+
+    public void setData(DataStorage data) {
+        this.data = data;
+    }
+
+    public List<Volume> getExternal() {
+        return external;
+    }
+
+    public void setExternal(List<Volume> external) {
+        this.external = external;
+    }
+}

--- a/debezium-operator-api/src/main/java/io/debezium/operator/api/model/runtime/storage/StorageType.java
+++ b/debezium-operator-api/src/main/java/io/debezium/operator/api/model/runtime/storage/StorageType.java
@@ -3,7 +3,7 @@
  *
  * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
-package io.debezium.operator.api.model;
+package io.debezium.operator.api.model.runtime.storage;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 

--- a/debezium-operator-api/src/main/java/io/debezium/operator/api/model/runtime/templates/ContainerEnvVar.java
+++ b/debezium-operator-api/src/main/java/io/debezium/operator/api/model/runtime/templates/ContainerEnvVar.java
@@ -3,7 +3,7 @@
  *
  * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
-package io.debezium.operator.api.model.templates;
+package io.debezium.operator.api.model.runtime.templates;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;

--- a/debezium-operator-api/src/main/java/io/debezium/operator/api/model/runtime/templates/ContainerTemplate.java
+++ b/debezium-operator-api/src/main/java/io/debezium/operator/api/model/runtime/templates/ContainerTemplate.java
@@ -3,10 +3,9 @@
  *
  * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
-package io.debezium.operator.api.model.templates;
+package io.debezium.operator.api.model.runtime.templates;
 
 import java.io.Serializable;
-import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
@@ -22,8 +21,6 @@ import io.fabric8.kubernetes.api.model.SecurityContext;
 public class ContainerTemplate implements Serializable {
     public static final long serialVersionUID = 1L;
 
-    @JsonPropertyDescription("Environment variables applied to the container.")
-    private List<ContainerEnvVar> env = List.of();
     @JsonPropertyDescription("CPU and memory resource requirements.")
     @JsonInclude(JsonInclude.Include.NON_NULL)
     @Documented.Field(k8Ref = "resourcerequirements-v1-core")
@@ -60,13 +57,5 @@ public class ContainerTemplate implements Serializable {
 
     public void setProbes(Probes probes) {
         this.probes = probes;
-    }
-
-    public List<ContainerEnvVar> getEnv() {
-        return env;
-    }
-
-    public void setEnv(List<ContainerEnvVar> env) {
-        this.env = env;
     }
 }

--- a/debezium-operator-api/src/main/java/io/debezium/operator/api/model/runtime/templates/HasMetadataTemplate.java
+++ b/debezium-operator-api/src/main/java/io/debezium/operator/api/model/runtime/templates/HasMetadataTemplate.java
@@ -3,7 +3,7 @@
  *
  * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
-package io.debezium.operator.api.model.templates;
+package io.debezium.operator.api.model.runtime.templates;
 
 /**
  * Interface for kubernetes objects witch metadata

--- a/debezium-operator-api/src/main/java/io/debezium/operator/api/model/runtime/templates/MetadataTemplate.java
+++ b/debezium-operator-api/src/main/java/io/debezium/operator/api/model/runtime/templates/MetadataTemplate.java
@@ -3,7 +3,7 @@
  *
  * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
-package io.debezium.operator.api.model.templates;
+package io.debezium.operator.api.model.runtime.templates;
 
 import java.io.Serializable;
 import java.util.HashMap;

--- a/debezium-operator-api/src/main/java/io/debezium/operator/api/model/runtime/templates/PodTemplate.java
+++ b/debezium-operator-api/src/main/java/io/debezium/operator/api/model/runtime/templates/PodTemplate.java
@@ -3,7 +3,7 @@
  *
  * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
-package io.debezium.operator.api.model.templates;
+package io.debezium.operator.api.model.runtime.templates;
 
 import java.io.Serializable;
 import java.util.List;

--- a/debezium-operator-api/src/main/java/io/debezium/operator/api/model/runtime/templates/Probe.java
+++ b/debezium-operator-api/src/main/java/io/debezium/operator/api/model/runtime/templates/Probe.java
@@ -3,7 +3,7 @@
  *
  * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
-package io.debezium.operator.api.model.templates;
+package io.debezium.operator.api.model.runtime.templates;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;

--- a/debezium-operator-api/src/main/java/io/debezium/operator/api/model/runtime/templates/Probes.java
+++ b/debezium-operator-api/src/main/java/io/debezium/operator/api/model/runtime/templates/Probes.java
@@ -3,7 +3,7 @@
  *
  * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
-package io.debezium.operator.api.model.templates;
+package io.debezium.operator.api.model.runtime.templates;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;

--- a/debezium-operator-api/src/main/java/io/debezium/operator/api/model/runtime/templates/Templates.java
+++ b/debezium-operator-api/src/main/java/io/debezium/operator/api/model/runtime/templates/Templates.java
@@ -3,16 +3,16 @@
  *
  * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
-package io.debezium.operator.api.model;
+package io.debezium.operator.api.model.runtime.templates;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
-import io.debezium.operator.api.model.templates.ContainerTemplate;
-import io.debezium.operator.api.model.templates.PodTemplate;
 import io.debezium.operator.docs.annotations.Documented;
+import io.fabric8.kubernetes.api.model.PersistentVolumeClaimSpec;
 
-@JsonPropertyOrder({ "container", "pod" })
+@JsonPropertyOrder({ "container", "pod", "volumeClaim" })
 @Documented
 public class Templates {
 
@@ -20,6 +20,11 @@ public class Templates {
     private ContainerTemplate container;
     @JsonPropertyDescription("Pod template.")
     private PodTemplate pod;
+
+    @JsonPropertyDescription("PVC template for data volume if no explicit claim is specified.")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @Documented.Field(k8Ref = "persistentvolumeclaimspec-v1-core")
+    private PersistentVolumeClaimSpec volumeClaim;
 
     public Templates() {
         this.pod = new PodTemplate();
@@ -40,5 +45,13 @@ public class Templates {
 
     public void setContainer(ContainerTemplate container) {
         this.container = container;
+    }
+
+    public PersistentVolumeClaimSpec getVolumeClaim() {
+        return volumeClaim;
+    }
+
+    public void setVolumeClaim(PersistentVolumeClaimSpec volumeClaim) {
+        this.volumeClaim = volumeClaim;
     }
 }

--- a/debezium-operator-core/src/main/java/io/debezium/operator/core/dependent/DeploymentDependent.java
+++ b/debezium-operator-core/src/main/java/io/debezium/operator/core/dependent/DeploymentDependent.java
@@ -17,10 +17,11 @@ import org.eclipse.microprofile.config.inject.ConfigProperty;
 
 import io.debezium.operator.api.model.CommonLabels;
 import io.debezium.operator.api.model.DebeziumServer;
-import io.debezium.operator.api.model.JmxConfig;
-import io.debezium.operator.api.model.Runtime;
-import io.debezium.operator.api.model.templates.ContainerTemplate;
-import io.debezium.operator.api.model.templates.PodTemplate;
+import io.debezium.operator.api.model.runtime.RuntimeEnvironment;
+import io.debezium.operator.api.model.runtime.jmx.JmxConfig;
+import io.debezium.operator.api.model.runtime.storage.RuntimeStorage;
+import io.debezium.operator.api.model.runtime.templates.ContainerTemplate;
+import io.debezium.operator.api.model.runtime.templates.PodTemplate;
 import io.debezium.operator.commons.util.StringUtils;
 import io.debezium.operator.core.VersionProvider;
 import io.fabric8.kubernetes.api.model.ConfigMapVolumeSourceBuilder;
@@ -41,6 +42,7 @@ import io.fabric8.kubernetes.api.model.ProbeBuilder;
 import io.fabric8.kubernetes.api.model.SecretVolumeSourceBuilder;
 import io.fabric8.kubernetes.api.model.Volume;
 import io.fabric8.kubernetes.api.model.VolumeBuilder;
+import io.fabric8.kubernetes.api.model.VolumeMount;
 import io.fabric8.kubernetes.api.model.VolumeMountBuilder;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.api.model.apps.DeploymentBuilder;
@@ -55,16 +57,15 @@ public class DeploymentDependent extends CRUDKubernetesDependentResource<Deploym
     public static final String CONFIG_FILE_NAME = "application.properties";
     public static final String CONFIG_DIR_PATH = "/debezium/conf";
     public static final String CONFIG_FILE_PATH = CONFIG_DIR_PATH + "/" + CONFIG_FILE_NAME;
+    public static final String DATA_VOLUME_NAME = "ds-data";
+    public static final String DATA_VOLUME_PATH = "/debezium/data";
     public static final String JMX_CONFIG_VOLUME_NAME = "ds-jmx-config";
     public static final String JMX_CONFIG_VOLUME_INIT_NAME = "ds-jmx-config-init";
     public static final String JMX_CONFIG_VOLUME_PATH = CONFIG_DIR_PATH + "/jmx";
     public static final String JMX_CONFIG_VOLUME_INIT_PATH = "/jmx";
-    public static final String DATA_VOLUME_NAME = "ds-data";
-    public static final String DATA_VOLUME_PATH = "/debezium/data";
-    public static final String EXTERNAL_VOLUME_PATH = "/debezium/external-configuration/%s";
+    public static final String EXTERNAL_VOLUME_PATH = "/debezium/external/%s";
     public static final int DEFAULT_HTTP_PORT = 8080;
     private static final String CONFIG_MD5_ANNOTATION = "debezium.io/server-config-md5";
-    private static final String INIT_CONTAINER_IMAGE = "registry.access.redhat.com/ubi8-micro:latest";
 
     @ConfigProperty(name = "debezium.image", defaultValue = DEFAULT_IMAGE)
     String defaultImage;
@@ -79,6 +80,7 @@ public class DeploymentDependent extends CRUDKubernetesDependentResource<Deploym
     @Override
     protected Deployment desired(DebeziumServer primary, Context<DebeziumServer> context) {
         var runtime = primary.getSpec().getRuntime();
+        var storage = runtime.getStorage();
         var templates = runtime.getTemplates();
         var name = primary.getMetadata().getName();
         var labels = CommonLabels.serverComponent(name).getMap();
@@ -87,7 +89,6 @@ public class DeploymentDependent extends CRUDKubernetesDependentResource<Deploym
         var sa = ServiceAccountDependent.serviceAccountNameFor(primary);
 
         var desiredContainer = desiredServerContainer(primary);
-        var dataVolume = desiredDataVolume(primary);
 
         var pod = new PodTemplateSpecBuilder()
                 .withMetadata(new ObjectMetaBuilder()
@@ -102,13 +103,12 @@ public class DeploymentDependent extends CRUDKubernetesDependentResource<Deploym
                                         .withName(name)
                                         .build())
                                 .build())
-                        .addToVolumes(dataVolume)
                         .addToContainers(desiredContainer)
                         .build())
                 .build();
 
         addTemplateConfigurationToPod(templates.getPod(), pod);
-        addExternalVolumesToPod(runtime, pod);
+        addStorageVolumesToPod(primary, storage, pod);
         addJmxConfigurationToPod(primary, pod);
 
         return new DeploymentBuilder()
@@ -131,7 +131,7 @@ public class DeploymentDependent extends CRUDKubernetesDependentResource<Deploym
      * Applies pod template configuration to pod if required
      *
      * @param template pod template configuration
-     * @param pod actual pod template spec
+     * @param pod      actual pod template spec
      */
     private void addTemplateConfigurationToPod(PodTemplate template, PodTemplateSpec pod) {
         var templateMeta = template.getMetadata();
@@ -145,21 +145,54 @@ public class DeploymentDependent extends CRUDKubernetesDependentResource<Deploym
     }
 
     /**
-     * Adds external volume definitions to pod if required
+     * Adds storage volume definitions to pod if required
      *
-     * @param runtime runtime configuration
-     * @param pod actual pod template spec
+     * @param primary
+     * @param storage runtime storage configuration
+     * @param pod     actual pod template spec
      */
-    private void addExternalVolumesToPod(Runtime runtime, PodTemplateSpec pod) {
+    private void addStorageVolumesToPod(DebeziumServer primary, RuntimeStorage storage, PodTemplateSpec pod) {
         var volumes = pod.getSpec().getVolumes();
-        volumes.addAll(runtime.getVolumes());
+
+        // add data volume
+        desiredDataVolume(primary)
+                .ifPresent(volumes::add);
+
+        // add external volumes
+        volumes.addAll(storage.getExternal());
+    }
+
+    private Optional<Volume> desiredDataVolume(DebeziumServer primary) {
+        var builder = new VolumeBuilder().withName(DATA_VOLUME_NAME);
+        var dataStorage = primary.getSpec().getRuntime().getStorage().getData();
+
+        switch (dataStorage.getType()) {
+            case EPHEMERAL -> builder
+                    .withEmptyDir(new EmptyDirVolumeSourceBuilder()
+                            .build());
+            case PERSISTENT -> builder
+                    .withPersistentVolumeClaim(new PersistentVolumeClaimVolumeSourceBuilder()
+                            .withClaimName(PvcDependent.pvcNameFor(primary))
+                            .build());
+        }
+        var volume = builder.build();
+        return Optional.of(volume);
+    }
+
+    private Optional<VolumeMount> desiredDataVolumeMount() {
+        var volumeMount = new VolumeMountBuilder()
+                .withName(DATA_VOLUME_NAME)
+                .withMountPath(DATA_VOLUME_PATH)
+                .build();
+
+        return Optional.of(volumeMount);
     }
 
     /**
      * Adds JMX configuration to pod if required
      *
      * @param primary primary resource
-     * @param pod target pod
+     * @param pod     target pod
      */
     private void addJmxConfigurationToPod(DebeziumServer primary, PodTemplateSpec pod) {
         var jmx = primary.getSpec().getRuntime().getJmx();
@@ -195,34 +228,8 @@ public class DeploymentDependent extends CRUDKubernetesDependentResource<Deploym
     }
 
     private void addTemplateConfigurationToContainer(ContainerTemplate template, Container container) {
-        var containerEnv = template.getEnv()
-                .stream()
-                .map(ce -> new EnvVar(ce.getName(), ce.getValue(), null))
-                .toList();
-
-        container.getEnv().addAll(containerEnv);
         container.setSecurityContext(template.getSecurityContext());
         container.setResources(template.getResources());
-    }
-
-    /**
-     * Creates desired data volume
-     *
-     * @param primary primary CR
-     * @return desired data volume
-     */
-    private Volume desiredDataVolume(DebeziumServer primary) {
-        var storageConfig = primary.getSpec().getStorage();
-        var builder = new VolumeBuilder().withName(DATA_VOLUME_NAME);
-
-        switch (storageConfig.getType()) {
-            case EPHEMERAL -> builder.withEmptyDir(new EmptyDirVolumeSourceBuilder()
-                    .build());
-            case PERSISTENT -> builder.withPersistentVolumeClaim(new PersistentVolumeClaimVolumeSourceBuilder()
-                    .withClaimName(storageConfig.getClaimName())
-                    .build());
-        }
-        return builder.build();
     }
 
     /**
@@ -235,6 +242,8 @@ public class DeploymentDependent extends CRUDKubernetesDependentResource<Deploym
         var quarkus = primary.getSpec().getQuarkus();
         var runtime = primary.getSpec().getRuntime();
         var template = runtime.getTemplates().getContainer();
+        var storage = runtime.getStorage();
+        var environment = runtime.getEnvironment();
         var jmx = primary.getSpec().getRuntime().getJmx();
         var probePort = quarkus.getConfig().getProps().getOrDefault("http.port", 8080);
         var livenessProbe = template.getProbes().getLiveness();
@@ -274,15 +283,11 @@ public class DeploymentDependent extends CRUDKubernetesDependentResource<Deploym
                         .withMountPath(CONFIG_FILE_PATH)
                         .withSubPath(CONFIG_FILE_NAME)
                         .build())
-                .addToVolumeMounts(new VolumeMountBuilder()
-                        .withName(DATA_VOLUME_NAME)
-                        .withMountPath(DATA_VOLUME_PATH)
-                        .build())
                 .build();
 
         addTemplateConfigurationToContainer(template, container);
-        addExternalEnvVariablesToContainer(runtime, container);
-        addExternalVolumeMountsToContainer(runtime, container);
+        addEnvVariablesToContainer(environment, container);
+        addStorageVolumeMountsToContainer(storage, container);
         addJmxConfigurationToContainer(jmx, container);
         return container;
     }
@@ -318,37 +323,49 @@ public class DeploymentDependent extends CRUDKubernetesDependentResource<Deploym
     }
 
     /**
-     * Adds external volume mounts to container if required
+     * Adds storage volume mounts to container if required
      *
-     * @param runtime runtime configuration
+     * @param storage   runtime configuration
      * @param container target container
      */
-    private void addExternalVolumeMountsToContainer(Runtime runtime, Container container) {
-        var volumeMounts = runtime.getVolumes().stream()
+    private void addStorageVolumeMountsToContainer(RuntimeStorage storage, Container container) {
+        var volumeMounts = container.getVolumeMounts();
+
+        // data volume
+        desiredDataVolumeMount()
+                .ifPresent(volumeMounts::add);
+
+        // external volumes
+        storage
+                .getExternal()
+                .stream()
                 .map(volume -> new VolumeMountBuilder()
                         .withName(volume.getName())
                         .withMountPath(EXTERNAL_VOLUME_PATH.formatted(volume.getName()))
-                        .withReadOnly()
                         .build())
-                .toList();
-
-        container.getVolumeMounts().addAll(volumeMounts);
+                .forEach(volumeMounts::add);
     }
 
     /**
      * Adds external environment variables to container in required
      *
-     * @param runtime runtime configuration
-     * @param container target container
+     * @param environment environment configuration
+     * @param container   target container
      */
-    private void addExternalEnvVariablesToContainer(Runtime runtime, Container container) {
-        container.getEnvFrom().addAll(runtime.getEnv());
+    private void addEnvVariablesToContainer(RuntimeEnvironment environment, Container container) {
+        var variables = environment.getVars()
+                .stream()
+                .map(ce -> new EnvVar(ce.getName(), ce.getValue(), null))
+                .toList();
+
+        container.getEnv().addAll(variables);
+        container.getEnvFrom().addAll(environment.getFrom());
     }
 
     /**
      * Adds JMX configuration to container if required
      *
-     * @param jmx jmx configuration
+     * @param jmx       jmx configuration
      * @param container target container
      */
     private void addJmxConfigurationToContainer(JmxConfig jmx, Container container) {
@@ -399,7 +416,7 @@ public class DeploymentDependent extends CRUDKubernetesDependentResource<Deploym
      * Adds JAVA_OPTS environment variable is not set on container.
      * If JAVA_OPTS already exists then new (and only new) options are added
      *
-     * @param newValue additional JAVA_OPTS in form of a map
+     * @param newValue  additional JAVA_OPTS in form of a map
      * @param container target container
      */
     private void mergeJavaOptsEnvVar(Map<String, ?> newValue, Container container) {

--- a/debezium-operator-core/src/main/java/io/debezium/operator/core/dependent/PvcDependent.java
+++ b/debezium-operator-core/src/main/java/io/debezium/operator/core/dependent/PvcDependent.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.operator.core.dependent;
+
+import java.util.Objects;
+
+import io.debezium.operator.api.model.DebeziumServer;
+import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
+import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
+import io.fabric8.kubernetes.api.model.PersistentVolumeClaimBuilder;
+import io.javaoperatorsdk.operator.api.reconciler.Context;
+import io.javaoperatorsdk.operator.processing.dependent.kubernetes.CRUDKubernetesDependentResource;
+
+public class PvcDependent extends CRUDKubernetesDependentResource<PersistentVolumeClaim, DebeziumServer> {
+
+    public static final String MANAGED_PVC_NAME = "%s-data-volume-claim";
+
+    public PvcDependent() {
+        super(PersistentVolumeClaim.class);
+    }
+
+    @Override
+    protected PersistentVolumeClaim desired(DebeziumServer primary, Context<DebeziumServer> context) {
+        var template = primary.getSpec().getRuntime().getTemplates().getVolumeClaim();
+
+        if (template == null) {
+            throw new IllegalStateException("Missing PVC template");
+        }
+
+        return new PersistentVolumeClaimBuilder()
+                .withMetadata(new ObjectMetaBuilder()
+                        .withName(MANAGED_PVC_NAME.formatted(primary.getMetadata().getName()))
+                        .withNamespace(primary.getMetadata().getNamespace())
+                        .build())
+                .withSpec(template)
+                .build();
+    }
+
+    private static String managedPvcNameFor(DebeziumServer primary) {
+        var name = primary.getMetadata().getName();
+        return MANAGED_PVC_NAME.formatted(name);
+    }
+
+    public static String pvcNameFor(DebeziumServer primary) {
+        var runtime = primary.getSpec().getRuntime();
+        var storage = runtime.getStorage().getData();
+        var providedPvcName = storage.getClaimName();
+        var managedPvcName = managedPvcNameFor(primary);
+
+        return Objects.requireNonNullElse(providedPvcName, managedPvcName);
+    }
+}

--- a/debezium-operator-core/src/main/java/io/debezium/operator/core/dependent/conditions/CreatePvc.java
+++ b/debezium-operator-core/src/main/java/io/debezium/operator/core/dependent/conditions/CreatePvc.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.operator.core.dependent.conditions;
+
+import io.debezium.operator.api.model.DebeziumServer;
+import io.debezium.operator.api.model.runtime.storage.StorageType;
+import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
+import io.javaoperatorsdk.operator.api.reconciler.Context;
+import io.javaoperatorsdk.operator.api.reconciler.dependent.DependentResource;
+import io.javaoperatorsdk.operator.processing.dependent.workflow.Condition;
+
+public class CreatePvc implements Condition<PersistentVolumeClaim, DebeziumServer> {
+    @Override
+    public boolean isMet(
+                         DependentResource<PersistentVolumeClaim, DebeziumServer> dependentResource,
+                         DebeziumServer primary,
+                         Context<DebeziumServer> context) {
+        var runtime = primary.getSpec().getRuntime();
+        var dataStorage = runtime.getStorage().getData();
+
+        return dataStorage.getType() == StorageType.PERSISTENT &&
+                dataStorage.getClaimName() == null;
+    }
+}

--- a/debezium-operator-core/src/main/java/io/debezium/operator/core/dependent/conditions/PvcReady.java
+++ b/debezium-operator-core/src/main/java/io/debezium/operator/core/dependent/conditions/PvcReady.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.operator.core.dependent.conditions;
+
+import io.debezium.operator.api.model.DebeziumServer;
+import io.debezium.operator.api.model.runtime.storage.StorageType;
+import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
+import io.fabric8.kubernetes.api.model.apps.Deployment;
+import io.javaoperatorsdk.operator.api.reconciler.Context;
+import io.javaoperatorsdk.operator.api.reconciler.dependent.DependentResource;
+import io.javaoperatorsdk.operator.processing.dependent.workflow.Condition;
+
+public class PvcReady implements Condition<Deployment, DebeziumServer> {
+    @Override
+    public boolean isMet(
+                         DependentResource<Deployment, DebeziumServer> dependentResource,
+                         DebeziumServer primary,
+                         Context<DebeziumServer> context) {
+        var runtime = primary.getSpec().getRuntime();
+        var dataStorage = runtime.getStorage().getData();
+
+        if (dataStorage.getType() == StorageType.EPHEMERAL) {
+            return true;
+        }
+        else if (dataStorage.getClaimName() != null) {
+            return true;
+        }
+
+        return context
+                .getSecondaryResource(PersistentVolumeClaim.class)
+                .isPresent();
+    }
+}

--- a/docs/reference.adoc
+++ b/docs/reference.adoc
@@ -17,7 +17,7 @@ Used in: <<debezium-operator-schema-reference-debeziumserverstatus, `+DebeziumSe
 
 [#debezium-operator-schema-reference-containerenvvar]
 ==== ContainerEnvVar Schema Reference
-Used in: <<debezium-operator-schema-reference-containertemplate, `+ContainerTemplate+`>>
+Used in: <<debezium-operator-schema-reference-runtimeenvironment, `+RuntimeEnvironment+`>>
 
 
 .ContainerEnvVar properties
@@ -37,10 +37,22 @@ Used in: <<debezium-operator-schema-reference-templates, `+Templates+`>>
 [cols="20%a,25%s,15%a,40%a",options="header"]
 |===
 | Property | Type | Default | Description
-| [[debezium-operator-schema-reference-containertemplate-env]]<<debezium-operator-schema-reference-containertemplate-env, `+env+`>> | <<debezium-operator-schema-reference-containerenvvar, `+List<ContainerEnvVar>+`>> |  | Environment variables applied to the container.
 | [[debezium-operator-schema-reference-containertemplate-resources]]<<debezium-operator-schema-reference-containertemplate-resources, `+resources+`>> | https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#resourcerequirements-v1-core[`+ResourceRequirements+`] |  | CPU and memory resource requirements.
 | [[debezium-operator-schema-reference-containertemplate-securitycontext]]<<debezium-operator-schema-reference-containertemplate-securitycontext, `+securityContext+`>> | https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#securitycontext-v1-core[`+SecurityContext+`] |  | Container security context.
 | [[debezium-operator-schema-reference-containertemplate-probes]]<<debezium-operator-schema-reference-containertemplate-probes, `+probes+`>> | <<debezium-operator-schema-reference-probes, `+Probes+`>> |  | Container probes configuration.
+|===
+
+[#debezium-operator-schema-reference-datastorage]
+==== DataStorage Schema Reference
+Used in: <<debezium-operator-schema-reference-runtimestorage, `+RuntimeStorage+`>>
+
+
+.DataStorage properties
+[cols="20%a,25%s,15%a,40%a",options="header"]
+|===
+| Property | Type | Default | Description
+| [[debezium-operator-schema-reference-datastorage-type]]<<debezium-operator-schema-reference-datastorage-type, `+type+`>> | ephemeral,persistent | ephemeral | Storage type.
+| [[debezium-operator-schema-reference-datastorage-claimname]]<<debezium-operator-schema-reference-datastorage-claimname, `+claimName+`>> | String |  | Name of persistent volume claim for persistent storage.
 |===
 
 [#debezium-operator-schema-reference-debeziumserver]
@@ -66,7 +78,6 @@ Used in: <<debezium-operator-schema-reference-debeziumserver, `+DebeziumServer+`
 | Property | Type | Default | Description
 | [[debezium-operator-schema-reference-debeziumserverspec-image]]<<debezium-operator-schema-reference-debeziumserverspec-image, `+image+`>> | String |  | Image used for Debezium Server container. This property takes precedence over version.
 | [[debezium-operator-schema-reference-debeziumserverspec-version]]<<debezium-operator-schema-reference-debeziumserverspec-version, `+version+`>> | String | same as operator | Version of Debezium Server to be used.
-| [[debezium-operator-schema-reference-debeziumserverspec-storage]]<<debezium-operator-schema-reference-debeziumserverspec-storage, `+storage+`>> | <<debezium-operator-schema-reference-storage, `+Storage+`>> |  | Storage configuration to be used by this instance of Debezium Server.
 | [[debezium-operator-schema-reference-debeziumserverspec-sink]]<<debezium-operator-schema-reference-debeziumserverspec-sink, `+sink+`>> | <<debezium-operator-schema-reference-sink, `+Sink+`>> |  | Sink configuration.
 | [[debezium-operator-schema-reference-debeziumserverspec-source]]<<debezium-operator-schema-reference-debeziumserverspec-source, `+source+`>> | <<debezium-operator-schema-reference-source, `+Source+`>> |  | Debezium source connector configuration.
 | [[debezium-operator-schema-reference-debeziumserverspec-format]]<<debezium-operator-schema-reference-debeziumserverspec-format, `+format+`>> | <<debezium-operator-schema-reference-format, `+Format+`>> |  | Message output format configuration.
@@ -234,11 +245,37 @@ Used in: <<debezium-operator-schema-reference-debeziumserverspec, `+DebeziumServ
 [cols="20%a,25%s,15%a,40%a",options="header"]
 |===
 | Property | Type | Default | Description
-| [[debezium-operator-schema-reference-runtime-env]]<<debezium-operator-schema-reference-runtime-env, `+env+`>> | https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#envfromsource-v1-core[`+List<EnvFromSource>+`] |  | Additional environment variables set from ConfigMaps or Secrets in containers.
+| [[debezium-operator-schema-reference-runtime-storage]]<<debezium-operator-schema-reference-runtime-storage, `+storage+`>> | <<debezium-operator-schema-reference-runtimestorage, `+RuntimeStorage+`>> |  | Storage configuration
+| [[debezium-operator-schema-reference-runtime-environment]]<<debezium-operator-schema-reference-runtime-environment, `+environment+`>> | <<debezium-operator-schema-reference-runtimeenvironment, `+RuntimeEnvironment+`>> |  | Additional environment variables used by this Debezium Server.
 | [[debezium-operator-schema-reference-runtime-jmx]]<<debezium-operator-schema-reference-runtime-jmx, `+jmx+`>> | <<debezium-operator-schema-reference-jmxconfig, `+JmxConfig+`>> |  | JMX configuration.
 | [[debezium-operator-schema-reference-runtime-templates]]<<debezium-operator-schema-reference-runtime-templates, `+templates+`>> | <<debezium-operator-schema-reference-templates, `+Templates+`>> |  | Debezium Server resource templates.
-| [[debezium-operator-schema-reference-runtime-volumes]]<<debezium-operator-schema-reference-runtime-volumes, `+volumes+`>> | https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#volume-v1-core[`+List<Volume>+`] |  | Additional volumes mounted to containers.
 | [[debezium-operator-schema-reference-runtime-serviceaccount]]<<debezium-operator-schema-reference-runtime-serviceaccount, `+serviceAccount+`>> | String |  | An existing service account used to run the Debezium Server pod
+|===
+
+[#debezium-operator-schema-reference-runtimeenvironment]
+==== RuntimeEnvironment Schema Reference
+Used in: <<debezium-operator-schema-reference-runtime, `+Runtime+`>>
+
+
+.RuntimeEnvironment properties
+[cols="20%a,25%s,15%a,40%a",options="header"]
+|===
+| Property | Type | Default | Description
+| [[debezium-operator-schema-reference-runtimeenvironment-vars]]<<debezium-operator-schema-reference-runtimeenvironment-vars, `+vars+`>> | <<debezium-operator-schema-reference-containerenvvar, `+List<ContainerEnvVar>+`>> |  | Environment variables applied to the container.
+| [[debezium-operator-schema-reference-runtimeenvironment-from]]<<debezium-operator-schema-reference-runtimeenvironment-from, `+from+`>> | https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#envfromsource-v1-core[`+List<EnvFromSource>+`] |  | Additional environment variables set from ConfigMaps or Secrets in containers.
+|===
+
+[#debezium-operator-schema-reference-runtimestorage]
+==== RuntimeStorage Schema Reference
+Used in: <<debezium-operator-schema-reference-runtime, `+Runtime+`>>
+
+
+.RuntimeStorage properties
+[cols="20%a,25%s,15%a,40%a",options="header"]
+|===
+| Property | Type | Default | Description
+| [[debezium-operator-schema-reference-runtimestorage-data]]<<debezium-operator-schema-reference-runtimestorage-data, `+data+`>> | <<debezium-operator-schema-reference-datastorage, `+DataStorage+`>> |  | File storage configuration used by this instance of Debezium Server.
+| [[debezium-operator-schema-reference-runtimestorage-external]]<<debezium-operator-schema-reference-runtimestorage-external, `+external+`>> | https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#volume-v1-core[`+List<Volume>+`] |  | Additional volumes mounted to /debezium/external
 |===
 
 [#debezium-operator-schema-reference-sink]
@@ -267,19 +304,6 @@ Used in: <<debezium-operator-schema-reference-debeziumserverspec, `+DebeziumServ
 | [[debezium-operator-schema-reference-source-config]]<<debezium-operator-schema-reference-source-config, `+config+`>> | Map |  | Source connector configuration properties.
 |===
 
-[#debezium-operator-schema-reference-storage]
-==== Storage Schema Reference
-Used in: <<debezium-operator-schema-reference-debeziumserverspec, `+DebeziumServerSpec+`>>
-
-
-.Storage properties
-[cols="20%a,25%s,15%a,40%a",options="header"]
-|===
-| Property | Type | Default | Description
-| [[debezium-operator-schema-reference-storage-type]]<<debezium-operator-schema-reference-storage-type, `+type+`>> | ephemeral,persistent | ephemeral | Storage type.
-| [[debezium-operator-schema-reference-storage-claimname]]<<debezium-operator-schema-reference-storage-claimname, `+claimName+`>> | String |  | Name of persistent volume claim for persistent storage.
-|===
-
 [#debezium-operator-schema-reference-templates]
 ==== Templates Schema Reference
 Used in: <<debezium-operator-schema-reference-runtime, `+Runtime+`>>
@@ -291,6 +315,7 @@ Used in: <<debezium-operator-schema-reference-runtime, `+Runtime+`>>
 | Property | Type | Default | Description
 | [[debezium-operator-schema-reference-templates-container]]<<debezium-operator-schema-reference-templates-container, `+container+`>> | <<debezium-operator-schema-reference-containertemplate, `+ContainerTemplate+`>> |  | Container template
 | [[debezium-operator-schema-reference-templates-pod]]<<debezium-operator-schema-reference-templates-pod, `+pod+`>> | <<debezium-operator-schema-reference-podtemplate, `+PodTemplate+`>> |  | Pod template.
+| [[debezium-operator-schema-reference-templates-volumeclaim]]<<debezium-operator-schema-reference-templates-volumeclaim, `+volumeClaim+`>> | https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#persistentvolumeclaimspec-v1-core[`+PersistentVolumeClaimSpec+`] |  | PVC template for data volume if no explicit claim is specified.
 |===
 
 [#debezium-operator-schema-reference-transformation]

--- a/k8/debeziumservers.debezium.io-v1.yml
+++ b/k8/debeziumservers.debezium.io-v1.yml
@@ -115,29 +115,46 @@ spec:
                 description: Configuration allowing the modification of various aspects
                   of Debezium Server runtime.
                 properties:
-                  env:
-                    description: Additional environment variables set from ConfigMaps
-                      or Secrets in containers.
-                    items:
-                      properties:
-                        configMapRef:
+                  environment:
+                    description: Additional environment variables used by this Debezium
+                      Server.
+                    properties:
+                      from:
+                        description: Additional environment variables set from ConfigMaps
+                          or Secrets in containers.
+                        items:
+                          properties:
+                            configMapRef:
+                              properties:
+                                name:
+                                  type: string
+                                optional:
+                                  type: boolean
+                              type: object
+                            prefix:
+                              type: string
+                            secretRef:
+                              properties:
+                                name:
+                                  type: string
+                                optional:
+                                  type: boolean
+                              type: object
+                          type: object
+                        type: array
+                      vars:
+                        description: Environment variables applied to the container.
+                        items:
                           properties:
                             name:
+                              description: The environment variable name.
                               type: string
-                            optional:
-                              type: boolean
-                          type: object
-                        prefix:
-                          type: string
-                        secretRef:
-                          properties:
-                            name:
+                            value:
+                              description: The environment variable value.
                               type: string
-                            optional:
-                              type: boolean
                           type: object
-                      type: object
-                    type: array
+                        type: array
+                    type: object
                   jmx:
                     description: JMX configuration.
                     properties:
@@ -170,24 +187,681 @@ spec:
                     description: An existing service account used to run the Debezium
                       Server pod
                     type: string
+                  storage:
+                    description: Storage configuration
+                    properties:
+                      data:
+                        description: File storage configuration used by this instance
+                          of Debezium Server.
+                        properties:
+                          claimName:
+                            description: Name of persistent volume claim for persistent
+                              storage.
+                            type: string
+                          type:
+                            description: Storage type.
+                            enum:
+                            - ephemeral
+                            - persistent
+                            type: string
+                        type: object
+                      external:
+                        description: Additional volumes mounted to /debezium/external
+                        items:
+                          properties:
+                            awsElasticBlockStore:
+                              properties:
+                                fsType:
+                                  type: string
+                                partition:
+                                  type: integer
+                                readOnly:
+                                  type: boolean
+                                volumeID:
+                                  type: string
+                              type: object
+                            azureDisk:
+                              properties:
+                                cachingMode:
+                                  type: string
+                                diskName:
+                                  type: string
+                                diskURI:
+                                  type: string
+                                fsType:
+                                  type: string
+                                kind:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                              type: object
+                            azureFile:
+                              properties:
+                                readOnly:
+                                  type: boolean
+                                secretName:
+                                  type: string
+                                shareName:
+                                  type: string
+                              type: object
+                            cephfs:
+                              properties:
+                                monitors:
+                                  items:
+                                    type: string
+                                  type: array
+                                path:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                secretFile:
+                                  type: string
+                                secretRef:
+                                  properties:
+                                    name:
+                                      type: string
+                                  type: object
+                                user:
+                                  type: string
+                              type: object
+                            cinder:
+                              properties:
+                                fsType:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                secretRef:
+                                  properties:
+                                    name:
+                                      type: string
+                                  type: object
+                                volumeID:
+                                  type: string
+                              type: object
+                            configMap:
+                              properties:
+                                defaultMode:
+                                  type: integer
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        type: integer
+                                      path:
+                                        type: string
+                                    type: object
+                                  type: array
+                                name:
+                                  type: string
+                                optional:
+                                  type: boolean
+                              type: object
+                            csi:
+                              properties:
+                                driver:
+                                  type: string
+                                fsType:
+                                  type: string
+                                nodePublishSecretRef:
+                                  properties:
+                                    name:
+                                      type: string
+                                  type: object
+                                readOnly:
+                                  type: boolean
+                                volumeAttributes:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                              type: object
+                            downwardAPI:
+                              properties:
+                                defaultMode:
+                                  type: integer
+                                items:
+                                  items:
+                                    properties:
+                                      fieldRef:
+                                        properties:
+                                          apiVersion:
+                                            type: string
+                                          fieldPath:
+                                            type: string
+                                        type: object
+                                      mode:
+                                        type: integer
+                                      path:
+                                        type: string
+                                      resourceFieldRef:
+                                        properties:
+                                          containerName:
+                                            type: string
+                                          divisor:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            x-kubernetes-int-or-string: true
+                                          resource:
+                                            type: string
+                                        type: object
+                                    type: object
+                                  type: array
+                              type: object
+                            emptyDir:
+                              properties:
+                                medium:
+                                  type: string
+                                sizeLimit:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  x-kubernetes-int-or-string: true
+                              type: object
+                            ephemeral:
+                              properties:
+                                volumeClaimTemplate:
+                                  properties:
+                                    metadata:
+                                      properties:
+                                        annotations:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                        creationTimestamp:
+                                          type: string
+                                        deletionGracePeriodSeconds:
+                                          type: integer
+                                        deletionTimestamp:
+                                          type: string
+                                        finalizers:
+                                          items:
+                                            type: string
+                                          type: array
+                                        generateName:
+                                          type: string
+                                        generation:
+                                          type: integer
+                                        labels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                        managedFields:
+                                          items:
+                                            properties:
+                                              apiVersion:
+                                                type: string
+                                              fieldsType:
+                                                type: string
+                                              fieldsV1:
+                                                type: object
+                                              manager:
+                                                type: string
+                                              operation:
+                                                type: string
+                                              subresource:
+                                                type: string
+                                              time:
+                                                type: string
+                                            type: object
+                                          type: array
+                                        name:
+                                          type: string
+                                        namespace:
+                                          type: string
+                                        ownerReferences:
+                                          items:
+                                            properties:
+                                              apiVersion:
+                                                type: string
+                                              blockOwnerDeletion:
+                                                type: boolean
+                                              controller:
+                                                type: boolean
+                                              kind:
+                                                type: string
+                                              name:
+                                                type: string
+                                              uid:
+                                                type: string
+                                            type: object
+                                          type: array
+                                        resourceVersion:
+                                          type: string
+                                        selfLink:
+                                          type: string
+                                        uid:
+                                          type: string
+                                      type: object
+                                    spec:
+                                      properties:
+                                        accessModes:
+                                          items:
+                                            type: string
+                                          type: array
+                                        dataSource:
+                                          properties:
+                                            apiGroup:
+                                              type: string
+                                            kind:
+                                              type: string
+                                            name:
+                                              type: string
+                                          type: object
+                                        dataSourceRef:
+                                          properties:
+                                            apiGroup:
+                                              type: string
+                                            kind:
+                                              type: string
+                                            name:
+                                              type: string
+                                            namespace:
+                                              type: string
+                                          type: object
+                                        resources:
+                                          properties:
+                                            claims:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                type: object
+                                              type: array
+                                            limits:
+                                              additionalProperties:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                x-kubernetes-int-or-string: true
+                                              type: object
+                                            requests:
+                                              additionalProperties:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                x-kubernetes-int-or-string: true
+                                              type: object
+                                          type: object
+                                        selector:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                          type: object
+                                        storageClassName:
+                                          type: string
+                                        volumeMode:
+                                          type: string
+                                        volumeName:
+                                          type: string
+                                      type: object
+                                  type: object
+                              type: object
+                            fc:
+                              properties:
+                                fsType:
+                                  type: string
+                                lun:
+                                  type: integer
+                                readOnly:
+                                  type: boolean
+                                targetWWNs:
+                                  items:
+                                    type: string
+                                  type: array
+                                wwids:
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            flexVolume:
+                              properties:
+                                driver:
+                                  type: string
+                                fsType:
+                                  type: string
+                                options:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                                readOnly:
+                                  type: boolean
+                                secretRef:
+                                  properties:
+                                    name:
+                                      type: string
+                                  type: object
+                              type: object
+                            flocker:
+                              properties:
+                                datasetName:
+                                  type: string
+                                datasetUUID:
+                                  type: string
+                              type: object
+                            gcePersistentDisk:
+                              properties:
+                                fsType:
+                                  type: string
+                                partition:
+                                  type: integer
+                                pdName:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                              type: object
+                            gitRepo:
+                              properties:
+                                directory:
+                                  type: string
+                                repository:
+                                  type: string
+                                revision:
+                                  type: string
+                              type: object
+                            glusterfs:
+                              properties:
+                                endpoints:
+                                  type: string
+                                path:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                              type: object
+                            hostPath:
+                              properties:
+                                path:
+                                  type: string
+                                type:
+                                  type: string
+                              type: object
+                            iscsi:
+                              properties:
+                                chapAuthDiscovery:
+                                  type: boolean
+                                chapAuthSession:
+                                  type: boolean
+                                fsType:
+                                  type: string
+                                initiatorName:
+                                  type: string
+                                iqn:
+                                  type: string
+                                iscsiInterface:
+                                  type: string
+                                lun:
+                                  type: integer
+                                portals:
+                                  items:
+                                    type: string
+                                  type: array
+                                readOnly:
+                                  type: boolean
+                                secretRef:
+                                  properties:
+                                    name:
+                                      type: string
+                                  type: object
+                                targetPortal:
+                                  type: string
+                              type: object
+                            name:
+                              type: string
+                            nfs:
+                              properties:
+                                path:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                server:
+                                  type: string
+                              type: object
+                            persistentVolumeClaim:
+                              properties:
+                                claimName:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                              type: object
+                            photonPersistentDisk:
+                              properties:
+                                fsType:
+                                  type: string
+                                pdID:
+                                  type: string
+                              type: object
+                            portworxVolume:
+                              properties:
+                                fsType:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                volumeID:
+                                  type: string
+                              type: object
+                            projected:
+                              properties:
+                                defaultMode:
+                                  type: integer
+                                sources:
+                                  items:
+                                    properties:
+                                      configMap:
+                                        properties:
+                                          items:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                mode:
+                                                  type: integer
+                                                path:
+                                                  type: string
+                                              type: object
+                                            type: array
+                                          name:
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        type: object
+                                      downwardAPI:
+                                        properties:
+                                          items:
+                                            items:
+                                              properties:
+                                                fieldRef:
+                                                  properties:
+                                                    apiVersion:
+                                                      type: string
+                                                    fieldPath:
+                                                      type: string
+                                                  type: object
+                                                mode:
+                                                  type: integer
+                                                path:
+                                                  type: string
+                                                resourceFieldRef:
+                                                  properties:
+                                                    containerName:
+                                                      type: string
+                                                    divisor:
+                                                      anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                      x-kubernetes-int-or-string: true
+                                                    resource:
+                                                      type: string
+                                                  type: object
+                                              type: object
+                                            type: array
+                                        type: object
+                                      secret:
+                                        properties:
+                                          items:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                mode:
+                                                  type: integer
+                                                path:
+                                                  type: string
+                                              type: object
+                                            type: array
+                                          name:
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        type: object
+                                      serviceAccountToken:
+                                        properties:
+                                          audience:
+                                            type: string
+                                          expirationSeconds:
+                                            type: integer
+                                          path:
+                                            type: string
+                                        type: object
+                                    type: object
+                                  type: array
+                              type: object
+                            quobyte:
+                              properties:
+                                group:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                registry:
+                                  type: string
+                                tenant:
+                                  type: string
+                                user:
+                                  type: string
+                                volume:
+                                  type: string
+                              type: object
+                            rbd:
+                              properties:
+                                fsType:
+                                  type: string
+                                image:
+                                  type: string
+                                keyring:
+                                  type: string
+                                monitors:
+                                  items:
+                                    type: string
+                                  type: array
+                                pool:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                secretRef:
+                                  properties:
+                                    name:
+                                      type: string
+                                  type: object
+                                user:
+                                  type: string
+                              type: object
+                            scaleIO:
+                              properties:
+                                fsType:
+                                  type: string
+                                gateway:
+                                  type: string
+                                protectionDomain:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                secretRef:
+                                  properties:
+                                    name:
+                                      type: string
+                                  type: object
+                                sslEnabled:
+                                  type: boolean
+                                storageMode:
+                                  type: string
+                                storagePool:
+                                  type: string
+                                system:
+                                  type: string
+                                volumeName:
+                                  type: string
+                              type: object
+                            secret:
+                              properties:
+                                defaultMode:
+                                  type: integer
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        type: integer
+                                      path:
+                                        type: string
+                                    type: object
+                                  type: array
+                                optional:
+                                  type: boolean
+                                secretName:
+                                  type: string
+                              type: object
+                            storageos:
+                              properties:
+                                fsType:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                secretRef:
+                                  properties:
+                                    name:
+                                      type: string
+                                  type: object
+                                volumeName:
+                                  type: string
+                                volumeNamespace:
+                                  type: string
+                              type: object
+                            vsphereVolume:
+                              properties:
+                                fsType:
+                                  type: string
+                                storagePolicyID:
+                                  type: string
+                                storagePolicyName:
+                                  type: string
+                                volumePath:
+                                  type: string
+                              type: object
+                          type: object
+                        type: array
+                    type: object
                   templates:
                     description: Debezium Server resource templates.
                     properties:
                       container:
                         description: Container template
                         properties:
-                          env:
-                            description: Environment variables applied to the container.
-                            items:
-                              properties:
-                                name:
-                                  description: The environment variable name.
-                                  type: string
-                                value:
-                                  description: The environment variable value.
-                                  type: string
-                              type: object
-                            type: array
                           probes:
                             description: Container probes configuration.
                             properties:
@@ -699,657 +1373,86 @@ spec:
                                 type: object
                             type: object
                         type: object
-                    type: object
-                  volumes:
-                    description: Additional volumes mounted to containers.
-                    items:
-                      properties:
-                        awsElasticBlockStore:
-                          properties:
-                            fsType:
-                              type: string
-                            partition:
-                              type: integer
-                            readOnly:
-                              type: boolean
-                            volumeID:
-                              type: string
-                          type: object
-                        azureDisk:
-                          properties:
-                            cachingMode:
-                              type: string
-                            diskName:
-                              type: string
-                            diskURI:
-                              type: string
-                            fsType:
-                              type: string
-                            kind:
-                              type: string
-                            readOnly:
-                              type: boolean
-                          type: object
-                        azureFile:
-                          properties:
-                            readOnly:
-                              type: boolean
-                            secretName:
-                              type: string
-                            shareName:
-                              type: string
-                          type: object
-                        cephfs:
-                          properties:
-                            monitors:
-                              items:
-                                type: string
-                              type: array
-                            path:
-                              type: string
-                            readOnly:
-                              type: boolean
-                            secretFile:
-                              type: string
-                            secretRef:
-                              properties:
-                                name:
-                                  type: string
-                              type: object
-                            user:
-                              type: string
-                          type: object
-                        cinder:
-                          properties:
-                            fsType:
-                              type: string
-                            readOnly:
-                              type: boolean
-                            secretRef:
-                              properties:
-                                name:
-                                  type: string
-                              type: object
-                            volumeID:
-                              type: string
-                          type: object
-                        configMap:
-                          properties:
-                            defaultMode:
-                              type: integer
+                      volumeClaim:
+                        description: PVC template for data volume if no explicit claim
+                          is specified.
+                        properties:
+                          accessModes:
                             items:
-                              items:
-                                properties:
-                                  key:
-                                    type: string
-                                  mode:
-                                    type: integer
-                                  path:
-                                    type: string
-                                type: object
-                              type: array
-                            name:
                               type: string
-                            optional:
-                              type: boolean
-                          type: object
-                        csi:
-                          properties:
-                            driver:
-                              type: string
-                            fsType:
-                              type: string
-                            nodePublishSecretRef:
-                              properties:
-                                name:
-                                  type: string
-                              type: object
-                            readOnly:
-                              type: boolean
-                            volumeAttributes:
-                              additionalProperties:
+                            type: array
+                          dataSource:
+                            properties:
+                              apiGroup:
                                 type: string
-                              type: object
-                          type: object
-                        downwardAPI:
-                          properties:
-                            defaultMode:
-                              type: integer
-                            items:
-                              items:
-                                properties:
-                                  fieldRef:
-                                    properties:
-                                      apiVersion:
-                                        type: string
-                                      fieldPath:
-                                        type: string
-                                    type: object
-                                  mode:
-                                    type: integer
-                                  path:
-                                    type: string
-                                  resourceFieldRef:
-                                    properties:
-                                      containerName:
-                                        type: string
-                                      divisor:
-                                        anyOf:
-                                        - type: integer
-                                        - type: string
-                                        x-kubernetes-int-or-string: true
-                                      resource:
-                                        type: string
-                                    type: object
-                                type: object
-                              type: array
-                          type: object
-                        emptyDir:
-                          properties:
-                            medium:
-                              type: string
-                            sizeLimit:
-                              anyOf:
-                              - type: integer
-                              - type: string
-                              x-kubernetes-int-or-string: true
-                          type: object
-                        ephemeral:
-                          properties:
-                            volumeClaimTemplate:
-                              properties:
-                                metadata:
+                              kind:
+                                type: string
+                              name:
+                                type: string
+                            type: object
+                          dataSourceRef:
+                            properties:
+                              apiGroup:
+                                type: string
+                              kind:
+                                type: string
+                              name:
+                                type: string
+                              namespace:
+                                type: string
+                            type: object
+                          resources:
+                            properties:
+                              claims:
+                                items:
                                   properties:
-                                    annotations:
-                                      additionalProperties:
-                                        type: string
-                                      type: object
-                                    creationTimestamp:
-                                      type: string
-                                    deletionGracePeriodSeconds:
-                                      type: integer
-                                    deletionTimestamp:
-                                      type: string
-                                    finalizers:
-                                      items:
-                                        type: string
-                                      type: array
-                                    generateName:
-                                      type: string
-                                    generation:
-                                      type: integer
-                                    labels:
-                                      additionalProperties:
-                                        type: string
-                                      type: object
-                                    managedFields:
-                                      items:
-                                        properties:
-                                          apiVersion:
-                                            type: string
-                                          fieldsType:
-                                            type: string
-                                          fieldsV1:
-                                            type: object
-                                          manager:
-                                            type: string
-                                          operation:
-                                            type: string
-                                          subresource:
-                                            type: string
-                                          time:
-                                            type: string
-                                        type: object
-                                      type: array
                                     name:
                                       type: string
-                                    namespace:
-                                      type: string
-                                    ownerReferences:
-                                      items:
-                                        properties:
-                                          apiVersion:
-                                            type: string
-                                          blockOwnerDeletion:
-                                            type: boolean
-                                          controller:
-                                            type: boolean
-                                          kind:
-                                            type: string
-                                          name:
-                                            type: string
-                                          uid:
-                                            type: string
-                                        type: object
-                                      type: array
-                                    resourceVersion:
-                                      type: string
-                                    selfLink:
-                                      type: string
-                                    uid:
-                                      type: string
                                   type: object
-                                spec:
+                                type: array
+                              limits:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  x-kubernetes-int-or-string: true
+                                type: object
+                              requests:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  x-kubernetes-int-or-string: true
+                                type: object
+                            type: object
+                          selector:
+                            properties:
+                              matchExpressions:
+                                items:
                                   properties:
-                                    accessModes:
+                                    key:
+                                      type: string
+                                    operator:
+                                      type: string
+                                    values:
                                       items:
                                         type: string
                                       type: array
-                                    dataSource:
-                                      properties:
-                                        apiGroup:
-                                          type: string
-                                        kind:
-                                          type: string
-                                        name:
-                                          type: string
-                                      type: object
-                                    dataSourceRef:
-                                      properties:
-                                        apiGroup:
-                                          type: string
-                                        kind:
-                                          type: string
-                                        name:
-                                          type: string
-                                        namespace:
-                                          type: string
-                                      type: object
-                                    resources:
-                                      properties:
-                                        claims:
-                                          items:
-                                            properties:
-                                              name:
-                                                type: string
-                                            type: object
-                                          type: array
-                                        limits:
-                                          additionalProperties:
-                                            anyOf:
-                                            - type: integer
-                                            - type: string
-                                            x-kubernetes-int-or-string: true
-                                          type: object
-                                        requests:
-                                          additionalProperties:
-                                            anyOf:
-                                            - type: integer
-                                            - type: string
-                                            x-kubernetes-int-or-string: true
-                                          type: object
-                                      type: object
-                                    selector:
-                                      properties:
-                                        matchExpressions:
-                                          items:
-                                            properties:
-                                              key:
-                                                type: string
-                                              operator:
-                                                type: string
-                                              values:
-                                                items:
-                                                  type: string
-                                                type: array
-                                            type: object
-                                          type: array
-                                        matchLabels:
-                                          additionalProperties:
-                                            type: string
-                                          type: object
-                                      type: object
-                                    storageClassName:
-                                      type: string
-                                    volumeMode:
-                                      type: string
-                                    volumeName:
-                                      type: string
                                   type: object
-                              type: object
-                          type: object
-                        fc:
-                          properties:
-                            fsType:
-                              type: string
-                            lun:
-                              type: integer
-                            readOnly:
-                              type: boolean
-                            targetWWNs:
-                              items:
-                                type: string
-                              type: array
-                            wwids:
-                              items:
-                                type: string
-                              type: array
-                          type: object
-                        flexVolume:
-                          properties:
-                            driver:
-                              type: string
-                            fsType:
-                              type: string
-                            options:
-                              additionalProperties:
-                                type: string
-                              type: object
-                            readOnly:
-                              type: boolean
-                            secretRef:
-                              properties:
-                                name:
+                                type: array
+                              matchLabels:
+                                additionalProperties:
                                   type: string
-                              type: object
-                          type: object
-                        flocker:
-                          properties:
-                            datasetName:
-                              type: string
-                            datasetUUID:
-                              type: string
-                          type: object
-                        gcePersistentDisk:
-                          properties:
-                            fsType:
-                              type: string
-                            partition:
-                              type: integer
-                            pdName:
-                              type: string
-                            readOnly:
-                              type: boolean
-                          type: object
-                        gitRepo:
-                          properties:
-                            directory:
-                              type: string
-                            repository:
-                              type: string
-                            revision:
-                              type: string
-                          type: object
-                        glusterfs:
-                          properties:
-                            endpoints:
-                              type: string
-                            path:
-                              type: string
-                            readOnly:
-                              type: boolean
-                          type: object
-                        hostPath:
-                          properties:
-                            path:
-                              type: string
-                            type:
-                              type: string
-                          type: object
-                        iscsi:
-                          properties:
-                            chapAuthDiscovery:
-                              type: boolean
-                            chapAuthSession:
-                              type: boolean
-                            fsType:
-                              type: string
-                            initiatorName:
-                              type: string
-                            iqn:
-                              type: string
-                            iscsiInterface:
-                              type: string
-                            lun:
-                              type: integer
-                            portals:
-                              items:
-                                type: string
-                              type: array
-                            readOnly:
-                              type: boolean
-                            secretRef:
-                              properties:
-                                name:
-                                  type: string
-                              type: object
-                            targetPortal:
-                              type: string
-                          type: object
-                        name:
-                          type: string
-                        nfs:
-                          properties:
-                            path:
-                              type: string
-                            readOnly:
-                              type: boolean
-                            server:
-                              type: string
-                          type: object
-                        persistentVolumeClaim:
-                          properties:
-                            claimName:
-                              type: string
-                            readOnly:
-                              type: boolean
-                          type: object
-                        photonPersistentDisk:
-                          properties:
-                            fsType:
-                              type: string
-                            pdID:
-                              type: string
-                          type: object
-                        portworxVolume:
-                          properties:
-                            fsType:
-                              type: string
-                            readOnly:
-                              type: boolean
-                            volumeID:
-                              type: string
-                          type: object
-                        projected:
-                          properties:
-                            defaultMode:
-                              type: integer
-                            sources:
-                              items:
-                                properties:
-                                  configMap:
-                                    properties:
-                                      items:
-                                        items:
-                                          properties:
-                                            key:
-                                              type: string
-                                            mode:
-                                              type: integer
-                                            path:
-                                              type: string
-                                          type: object
-                                        type: array
-                                      name:
-                                        type: string
-                                      optional:
-                                        type: boolean
-                                    type: object
-                                  downwardAPI:
-                                    properties:
-                                      items:
-                                        items:
-                                          properties:
-                                            fieldRef:
-                                              properties:
-                                                apiVersion:
-                                                  type: string
-                                                fieldPath:
-                                                  type: string
-                                              type: object
-                                            mode:
-                                              type: integer
-                                            path:
-                                              type: string
-                                            resourceFieldRef:
-                                              properties:
-                                                containerName:
-                                                  type: string
-                                                divisor:
-                                                  anyOf:
-                                                  - type: integer
-                                                  - type: string
-                                                  x-kubernetes-int-or-string: true
-                                                resource:
-                                                  type: string
-                                              type: object
-                                          type: object
-                                        type: array
-                                    type: object
-                                  secret:
-                                    properties:
-                                      items:
-                                        items:
-                                          properties:
-                                            key:
-                                              type: string
-                                            mode:
-                                              type: integer
-                                            path:
-                                              type: string
-                                          type: object
-                                        type: array
-                                      name:
-                                        type: string
-                                      optional:
-                                        type: boolean
-                                    type: object
-                                  serviceAccountToken:
-                                    properties:
-                                      audience:
-                                        type: string
-                                      expirationSeconds:
-                                        type: integer
-                                      path:
-                                        type: string
-                                    type: object
                                 type: object
-                              type: array
-                          type: object
-                        quobyte:
-                          properties:
-                            group:
-                              type: string
-                            readOnly:
-                              type: boolean
-                            registry:
-                              type: string
-                            tenant:
-                              type: string
-                            user:
-                              type: string
-                            volume:
-                              type: string
-                          type: object
-                        rbd:
-                          properties:
-                            fsType:
-                              type: string
-                            image:
-                              type: string
-                            keyring:
-                              type: string
-                            monitors:
-                              items:
-                                type: string
-                              type: array
-                            pool:
-                              type: string
-                            readOnly:
-                              type: boolean
-                            secretRef:
-                              properties:
-                                name:
-                                  type: string
-                              type: object
-                            user:
-                              type: string
-                          type: object
-                        scaleIO:
-                          properties:
-                            fsType:
-                              type: string
-                            gateway:
-                              type: string
-                            protectionDomain:
-                              type: string
-                            readOnly:
-                              type: boolean
-                            secretRef:
-                              properties:
-                                name:
-                                  type: string
-                              type: object
-                            sslEnabled:
-                              type: boolean
-                            storageMode:
-                              type: string
-                            storagePool:
-                              type: string
-                            system:
-                              type: string
-                            volumeName:
-                              type: string
-                          type: object
-                        secret:
-                          properties:
-                            defaultMode:
-                              type: integer
-                            items:
-                              items:
-                                properties:
-                                  key:
-                                    type: string
-                                  mode:
-                                    type: integer
-                                  path:
-                                    type: string
-                                type: object
-                              type: array
-                            optional:
-                              type: boolean
-                            secretName:
-                              type: string
-                          type: object
-                        storageos:
-                          properties:
-                            fsType:
-                              type: string
-                            readOnly:
-                              type: boolean
-                            secretRef:
-                              properties:
-                                name:
-                                  type: string
-                              type: object
-                            volumeName:
-                              type: string
-                            volumeNamespace:
-                              type: string
-                          type: object
-                        vsphereVolume:
-                          properties:
-                            fsType:
-                              type: string
-                            storagePolicyID:
-                              type: string
-                            storagePolicyName:
-                              type: string
-                            volumePath:
-                              type: string
-                          type: object
-                      type: object
-                    type: array
+                            type: object
+                          storageClassName:
+                            type: string
+                          volumeMode:
+                            type: string
+                          volumeName:
+                            type: string
+                        type: object
+                    type: object
                 type: object
               sink:
                 description: Sink configuration.
@@ -1384,20 +1487,6 @@ spec:
                         x-kubernetes-preserve-unknown-fields: true
                     type: object
                     x-kubernetes-preserve-unknown-fields: true
-                type: object
-              storage:
-                description: Storage configuration to be used by this instance of
-                  Debezium Server.
-                properties:
-                  claimName:
-                    description: Name of persistent volume claim for persistent storage.
-                    type: string
-                  type:
-                    description: Storage type.
-                    enum:
-                    - ephemeral
-                    - persistent
-                    type: string
                 type: object
               transforms:
                 description: Single Message Transformations employed by this instance

--- a/k8/kubernetes.yml
+++ b/k8/kubernetes.yml
@@ -31,18 +31,6 @@ rules:
   - apiGroups:
       - ""
     resources:
-      - serviceaccounts
-    verbs:
-      - get
-      - list
-      - watch
-      - patch
-      - update
-      - delete
-      - create
-  - apiGroups:
-      - ""
-    resources:
       - configmaps
     verbs:
       - get
@@ -56,18 +44,6 @@ rules:
       - rbac.authorization.k8s.io
     resources:
       - rolebindings
-    verbs:
-      - get
-      - list
-      - watch
-      - patch
-      - update
-      - delete
-      - create
-  - apiGroups:
-      - rbac.authorization.k8s.io
-    resources:
-      - roles
     verbs:
       - get
       - list
@@ -92,6 +68,42 @@ rules:
       - ""
     resources:
       - services
+    verbs:
+      - get
+      - list
+      - watch
+      - patch
+      - update
+      - delete
+      - create
+  - apiGroups:
+      - ""
+    resources:
+      - persistentvolumeclaims
+    verbs:
+      - get
+      - list
+      - watch
+      - patch
+      - update
+      - delete
+      - create
+  - apiGroups:
+      - ""
+    resources:
+      - serviceaccounts
+    verbs:
+      - get
+      - list
+      - watch
+      - patch
+      - update
+      - delete
+      - create
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - roles
     verbs:
       - get
       - list


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-7448

- [x] Move all storage and env management under `.runtime.storage` and `.runtime.environment`
- [x] Allow operator to create PVC if PVC name is not explicitly provided (this includes the ability to set a PVC spec template, in order to customise the creation)