### PR TITLE
DBZ-7503 Allow parsing whole ConfigProperties map

### DIFF
--- a/debezium-operator-api/src/main/java/io/debezium/operator/api/model/ConfigProperties.java
+++ b/debezium-operator-api/src/main/java/io/debezium/operator/api/model/ConfigProperties.java
@@ -10,6 +10,7 @@ import java.util.Map;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 
 import io.debezium.operator.api.config.ConfigMappable;
 import io.debezium.operator.api.config.ConfigMapping;
@@ -23,6 +24,11 @@ public class ConfigProperties implements ConfigMappable {
     @JsonAnyGetter
     public Map<String, Object> getProps() {
         return props;
+    }
+
+    @JsonIgnore
+    public void setAllProps(Map<String, Object> props) {
+        this.props.putAll(props);
     }
 
     @JsonAnySetter


### PR DESCRIPTION
This PR allows parsing whole properties Map, so other projects that use the operator model can prepare map outside with whatever creation process of Debezium sink and sources properties.