### PR TITLE
Add pod securityContext from templates

### DIFF
--- a/debezium-operator-core/src/main/java/io/debezium/operator/core/dependent/DeploymentDependent.java
+++ b/debezium-operator-core/src/main/java/io/debezium/operator/core/dependent/DeploymentDependent.java
@@ -138,6 +138,7 @@ public class DeploymentDependent extends CRUDKubernetesDependentResource<Deploym
         var podSpec = pod.getSpec();
         var podMeta = pod.getMetadata();
 
+        podSpec.setSecurityContext(template.getSecurityContext());
         podSpec.setAffinity(template.getAffinity());
         podSpec.setImagePullSecrets(template.getImagePullSecrets());
         podMeta.getLabels().putAll(templateMeta.getLabels());


### PR DESCRIPTION
Add missing securityContext from templates.

Currently only the container securityContext is being set. When using file based storage for offsets this requires the container to run as root to be able to access the volume since we can't set the fsGroup on the pod level