### PR TITLE
Fix bug with multiple transforms

### DIFF
--- a/debezium-operator-api/src/main/java/io/debezium/operator/api/config/ConfigMapping.java
+++ b/debezium-operator-api/src/main/java/io/debezium/operator/api/config/ConfigMapping.java
@@ -105,9 +105,8 @@ public final class ConfigMapping {
 
         named.stream()
                 .map(NamedItem::name)
-                .reduce((x, y) -> String.join(","))
+                .reduce((x, y) -> x + "," + y)
                 .ifPresent(names -> put(key, names));
-
 
         named.forEach(item -> putAll(key + "." + item.name, item.item));
         return this;

--- a/debezium-operator-api/src/test/java/io/debezium/operator/api/config/ConfigMappingTest.java
+++ b/debezium-operator-api/src/test/java/io/debezium/operator/api/config/ConfigMappingTest.java
@@ -83,7 +83,7 @@ public class ConfigMappingTest {
 
         config.putList("transforms", transformations, "Reroute");
 
-        assertThat(config.getAsMap()).containsEntry("transforms", "");
+        assertThat(config.getAsMap()).containsEntry("transforms", "Reroute0,Reroute1");
         assertThat(config.getAsMap()).containsEntry("transforms.Reroute0.type", "io.debezium.transforms.ByLogicalTableRouter");
         assertThat(config.getAsMap()).containsEntry("transforms.Reroute0.negate", "false");
         assertThat(config.getAsMap()).containsEntry("transforms.Reroute1.type", "io.debezium.transforms.ByLogicalTableRouter");
@@ -93,7 +93,7 @@ public class ConfigMappingTest {
                 "transforms.Reroute0.type=io.debezium.transforms.ByLogicalTableRouter\n" +
                 "transforms.Reroute1.negate=true\n" +
                 "transforms.Reroute1.type=io.debezium.transforms.ByLogicalTableRouter\n" +
-                "transforms=");
+                "transforms=Reroute0,Reroute1");
     }
 
     @Test


### PR DESCRIPTION
When you apply multiple transformations, you run into a bug with the operator where the t0,t1 isn't applied like it should be. There is something wrong with String.join(","). Realistically we just need to add a comma between.

Also fixes the incorrect test so we can validate this better moving forward.

Real World Example

1 Transformation ✅ 
```
debezium.transforms.t0.negate=true
debezium.transforms.t0.predicate=TopicNameMatches
debezium.transforms.t0.topic.regex=<redacted>
debezium.transforms.t0.topic.replacement=<redacted>
debezium.transforms.t0.type=io.debezium.transforms.ByLogicalTableRouter
debezium.transforms=t0
```

When you have multiple transformations ❌ 
```
debezium.transforms.t0.negate=false
debezium.transforms.t0.predicate=TopicNameMatches
debezium.transforms.t0.type=<custom transform>
debezium.transforms.t1.negate=false
debezium.transforms.t1.predicate=TopicNameMatches
debezium.transforms.t1.regex=<redacted>
debezium.transforms.t1.replacement=<redacted
debezium.transforms.t1.type=org.apache.kafka.connect.transforms.RegexRouter
debezium.transforms.t2.negate=false
debezium.transforms.t2.predicate=TopicNameMatches
debezium.transforms.t2.type=<custom transform>
debezium.transforms.t3.negate=false
debezium.transforms.t3.predicate=TopicNameMatches
debezium.transforms.t3.type=<custom transform>
debezium.transforms=
```

Note the `debezium.transforms` is empty in the second example