### PR TITLE
DBZ-8061: Provided Service Account instead of managed

### DIFF
--- a/debezium-operator-core/src/main/java/io/debezium/operator/core/DebeziumServerReconciler.java
+++ b/debezium-operator-core/src/main/java/io/debezium/operator/core/DebeziumServerReconciler.java
@@ -31,6 +31,7 @@ import io.debezium.operator.core.dependent.conditions.DeploymentReady;
 import io.debezium.operator.core.dependent.conditions.JmxEnabled;
 import io.debezium.operator.core.dependent.conditions.JmxExporterEnabled;
 import io.debezium.operator.core.dependent.conditions.PvcReady;
+import io.debezium.operator.core.dependent.conditions.ServiceAccountReady;
 import io.javaoperatorsdk.operator.api.reconciler.Constants;
 import io.javaoperatorsdk.operator.api.reconciler.Context;
 import io.javaoperatorsdk.operator.api.reconciler.ControllerConfiguration;
@@ -47,9 +48,8 @@ import io.quarkus.logging.Log;
         @Dependent(name = "pvc", type = PvcDependent.class, reconcilePrecondition = CreatePvc.class),
         @Dependent(name = "role", type = RoleDependent.class),
         @Dependent(name = "role-binding", type = RoleBindingDependent.class, dependsOn = {
-                "service-account",
                 "role"
-        }),
+        }, reconcilePrecondition = ServiceAccountReady.class),
         @Dependent(name = "config", type = ConfigMapDependent.class),
         @Dependent(name = "deployment", type = DeploymentDependent.class, dependsOn = {
                 "config",

--- a/debezium-operator-core/src/main/java/io/debezium/operator/core/dependent/RoleBindingDependent.java
+++ b/debezium-operator-core/src/main/java/io/debezium/operator/core/dependent/RoleBindingDependent.java
@@ -7,7 +7,6 @@ package io.debezium.operator.core.dependent;
 
 import io.debezium.operator.api.model.DebeziumServer;
 import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
-import io.fabric8.kubernetes.api.model.ServiceAccount;
 import io.fabric8.kubernetes.api.model.rbac.Role;
 import io.fabric8.kubernetes.api.model.rbac.RoleBinding;
 import io.fabric8.kubernetes.api.model.rbac.RoleBindingBuilder;
@@ -26,9 +25,7 @@ public class RoleBindingDependent
 
     @Override
     protected RoleBinding desired(DebeziumServer primary, Context<DebeziumServer> context) {
-        var sa = context.getSecondaryResource(ServiceAccount.class)
-                .map(r -> r.getMetadata().getName())
-                .orElseThrow();
+        var sa = ServiceAccountDependent.serviceAccountNameFor(primary);
 
         var role = context.getSecondaryResource(Role.class)
                 .map(r -> r.getMetadata().getName())

--- a/debezium-operator-core/src/main/java/io/debezium/operator/core/dependent/conditions/ServiceAccountReady.java
+++ b/debezium-operator-core/src/main/java/io/debezium/operator/core/dependent/conditions/ServiceAccountReady.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.operator.core.dependent.conditions;
+
+import io.debezium.operator.api.model.DebeziumServer;
+import io.debezium.operator.core.dependent.ServiceAccountDependent;
+import io.fabric8.kubernetes.api.model.ServiceAccount;
+import io.javaoperatorsdk.operator.api.reconciler.Context;
+import io.javaoperatorsdk.operator.api.reconciler.dependent.DependentResource;
+import io.javaoperatorsdk.operator.processing.dependent.workflow.Condition;
+
+public class ServiceAccountReady implements Condition<ServiceAccount, DebeziumServer> {
+    @Override
+    public boolean isMet(
+                         DependentResource<ServiceAccount, DebeziumServer> dependentResource,
+                         DebeziumServer primary,
+                         Context<DebeziumServer> context) {
+        var namespace = primary.getMetadata().getNamespace();
+        var serviceAccountName = ServiceAccountDependent.serviceAccountNameFor(primary);
+        return context.getClient().serviceAccounts().inNamespace(namespace).withName(serviceAccountName).get() != null;
+    }
+}


### PR DESCRIPTION
Adding a potential solution for: https://issues.redhat.com/browse/DBZ-8061

I know this is the way that the operator currently handles PVC, JMX etc. Long term I think it would be better to have ReadOnly Dependents so the reconciliation tree isn't hard to follow.

Tested locally with `serviceAccount: default`

```
Name:         <name>-config-view-role-binding
Labels:       <none>
Annotations:  javaoperatorsdk.io/previous: <uuid>
Role:
  Kind:  Role
  Name:  <name>-config-view
Subjects:
  Kind            Name     Namespace
  ----            ----     ---------
  ServiceAccount  default 
```

Also tested with the traditional managed service account.