### PR TITLE
DBZ-8654 Update QOSDK to 6.9.3 that introduces the possibility to override the operator image through the values.yaml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,7 @@
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.version>3.17.0</quarkus.platform.version>
-        <quarkus.operator.sdk.version>6.9.1</quarkus.operator.sdk.version>
+        <quarkus.operator.sdk.version>6.9.3</quarkus.operator.sdk.version>
         <quarkus.application.version>${version.debezium.parsed}</quarkus.application.version>
 
         <!-- Operator and Image configuration -->


### PR DESCRIPTION
closes: https://issues.redhat.com/browse/DBZ-8654