### PR TITLE
DBZ-9010 Enable dependabot for maven dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,4 +7,10 @@ updates:
       interval: "weekly"
     commit-message:
       prefix: "[ci] "
-
+  # Updates for Maven dependencies in the root pom
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "[ci] "


### PR DESCRIPTION
closes: https://issues.redhat.com/browse/DBZ-9010