### PR TITLE
debezium/dbz#1796 Update 002_kafka-ephemeral.yml to use recent Strimzi CRD

### DIFF
--- a/examples/postgres/002_kafka-ephemeral.yml
+++ b/examples/postgres/002_kafka-ephemeral.yml
@@ -1,11 +1,28 @@
 apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaNodePool
+metadata:
+  name: dual-role
+  labels:
+    strimzi.io/cluster: dbz-kafka
+spec:
+  replicas: 1
+  roles:
+    - controller
+    - broker
+  storage:
+    type: ephemeral
+---
+apiVersion: kafka.strimzi.io/v1beta2
 kind: Kafka
 metadata:
   name: dbz-kafka
+  annotations:
+    strimzi.io/kraft: enabled
+    strimzi.io/node-pools: enabled
 spec:
   kafka:
-    version: 3.8.0
-    replicas: 1
+    version: 4.2.0
+    metadataVersion: "4.2-IV0"
     listeners:
       - name: plain
         port: 9092
@@ -21,13 +38,6 @@ spec:
       transaction.state.log.min.isr: 1
       default.replication.factor: 1
       min.insync.replicas: 1
-      inter.broker.protocol.version: "3.8"
-    storage:
-      type: ephemeral
-  zookeeper:
-    replicas: 1
-    storage:
-      type: ephemeral
   entityOperator:
     topicOperator: {}
     userOperator: {}


### PR DESCRIPTION
closes: debezium/dbz#1796