### PR TITLE
debezium/dbz#1591 Add imagePullPolicy support to DebeziumServer CRD

### DIFF
--- a/debezium-operator-api/src/main/java/io/debezium/operator/api/model/runtime/templates/ContainerTemplate.java
+++ b/debezium-operator-api/src/main/java/io/debezium/operator/api/model/runtime/templates/ContainerTemplate.java
@@ -15,7 +15,7 @@ import io.debezium.operator.docs.annotations.Documented;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
 import io.fabric8.kubernetes.api.model.SecurityContext;
 
-@JsonPropertyOrder({ "resources", "securityContext", "probes" })
+@JsonPropertyOrder({ "resources", "securityContext", "probes", "imagePullPolicy" })
 @JsonInclude(JsonInclude.Include.NON_DEFAULT)
 @Documented
 public class ContainerTemplate implements Serializable {
@@ -34,6 +34,10 @@ public class ContainerTemplate implements Serializable {
     @JsonPropertyDescription("Container probes configuration.")
     @JsonInclude(JsonInclude.Include.NON_NULL)
     private Probes probes = new Probes();
+
+    @JsonPropertyDescription("Image pull policy for the container.")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private String imagePullPolicy;
 
     public SecurityContext getSecurityContext() {
         return securityContext;
@@ -57,5 +61,13 @@ public class ContainerTemplate implements Serializable {
 
     public void setProbes(Probes probes) {
         this.probes = probes;
+    }
+
+    public String getImagePullPolicy() {
+        return imagePullPolicy;
+    }
+
+    public void setImagePullPolicy(String imagePullPolicy) {
+        this.imagePullPolicy = imagePullPolicy;
     }
 }

--- a/debezium-operator-api/src/main/java/io/debezium/operator/api/model/runtime/templates/ContainerTemplate.java
+++ b/debezium-operator-api/src/main/java/io/debezium/operator/api/model/runtime/templates/ContainerTemplate.java
@@ -37,7 +37,7 @@ public class ContainerTemplate implements Serializable {
 
     @JsonPropertyDescription("Image pull policy for the container.")
     @JsonInclude(JsonInclude.Include.NON_NULL)
-    private String imagePullPolicy;
+    private ImagePullPolicy imagePullPolicy;
 
     public SecurityContext getSecurityContext() {
         return securityContext;
@@ -63,11 +63,11 @@ public class ContainerTemplate implements Serializable {
         this.probes = probes;
     }
 
-    public String getImagePullPolicy() {
+    public ImagePullPolicy getImagePullPolicy() {
         return imagePullPolicy;
     }
 
-    public void setImagePullPolicy(String imagePullPolicy) {
+    public void setImagePullPolicy(ImagePullPolicy imagePullPolicy) {
         this.imagePullPolicy = imagePullPolicy;
     }
 }

--- a/debezium-operator-api/src/main/java/io/debezium/operator/api/model/runtime/templates/ImagePullPolicy.java
+++ b/debezium-operator-api/src/main/java/io/debezium/operator/api/model/runtime/templates/ImagePullPolicy.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.operator.api.model.runtime.templates;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import io.debezium.operator.docs.annotations.Documented;
+
+@Documented(hidden = true)
+public enum ImagePullPolicy {
+    @JsonProperty("Always")
+    ALWAYS("Always"),
+    @JsonProperty("IfNotPresent")
+    IF_NOT_PRESENT("IfNotPresent"),
+    @JsonProperty("Never")
+    NEVER("Never");
+
+    private final String value;
+
+    ImagePullPolicy(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+}

--- a/debezium-operator-core/src/main/java/io/debezium/operator/core/dependent/DeploymentDependent.java
+++ b/debezium-operator-core/src/main/java/io/debezium/operator/core/dependent/DeploymentDependent.java
@@ -282,7 +282,10 @@ public class DeploymentDependent extends CRUDKubernetesDependentResource<Deploym
     private void addTemplateConfigurationToContainer(ContainerTemplate template, Container container) {
         container.setSecurityContext(template.getSecurityContext());
         container.setResources(template.getResources());
-        container.setImagePullPolicy(template.getImagePullPolicy());
+        var imagePullPolicy = template.getImagePullPolicy();
+        if (imagePullPolicy != null) {
+            container.setImagePullPolicy(imagePullPolicy.getValue());
+        }
     }
 
     /**

--- a/debezium-operator-core/src/main/java/io/debezium/operator/core/dependent/DeploymentDependent.java
+++ b/debezium-operator-core/src/main/java/io/debezium/operator/core/dependent/DeploymentDependent.java
@@ -282,6 +282,7 @@ public class DeploymentDependent extends CRUDKubernetesDependentResource<Deploym
     private void addTemplateConfigurationToContainer(ContainerTemplate template, Container container) {
         container.setSecurityContext(template.getSecurityContext());
         container.setResources(template.getResources());
+        container.setImagePullPolicy(template.getImagePullPolicy());
     }
 
     /**

--- a/debezium-operator-core/src/test/java/io/debezium/operator/core/DebeziumServerReconcilerTest.java
+++ b/debezium-operator-core/src/test/java/io/debezium/operator/core/DebeziumServerReconcilerTest.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import io.debezium.operator.api.model.DebeziumServer;
+import io.debezium.operator.api.model.runtime.templates.ImagePullPolicy;
 import io.debezium.operator.core.dependent.DeploymentDependent;
 import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
 import io.fabric8.kubernetes.client.KubernetesClient;
@@ -47,8 +48,6 @@ public class DebeziumServerReconcilerTest {
 
     @Test
     void shouldReconcileDebeziumServer() {
-        final String imagePullPolicy = "IfNotPresent";
-        debeziumServer.getSpec().getRuntime().getTemplates().getContainer().setImagePullPolicy(imagePullPolicy);
         client.resource(debeziumServer).create();
         await().ignoreException(NullPointerException.class).atMost(2, TimeUnit.MINUTES).untilAsserted(() -> {
             // check config map
@@ -80,13 +79,32 @@ public class DebeziumServerReconcilerTest {
             assertThat(container.getImage()).isEqualTo(debeziumServer.getSpec().getImage());
             assertThat(container.getLivenessProbe()).isNotNull();
             assertThat(container.getReadinessProbe()).isNotNull();
-            assertThat(container.getImagePullPolicy()).isEqualTo(imagePullPolicy);
             assertThat(container.getVolumeMounts()).hasSize(2);
             assertThat(container.getVolumeMounts()).anyMatch(mount -> mount.getName().equals(DeploymentDependent.CONFIG_VOLUME_NAME) &&
                     mount.getMountPath().equals(DeploymentDependent.CONFIG_FILE_PATH) &&
                     mount.getSubPath().equals(DeploymentDependent.CONFIG_FILE_NAME));
             assertThat(container.getVolumeMounts()).anyMatch(mount -> mount.getName().equals(DeploymentDependent.DATA_VOLUME_NAME) &&
                     mount.getMountPath().equals(DeploymentDependent.DATA_VOLUME_PATH));
+        });
+    }
+
+    @Test
+    void shouldReconcileDebeziumServerWithImagePullPolicy() {
+        final ImagePullPolicy imagePullPolicy = ImagePullPolicy.IF_NOT_PRESENT;
+        debeziumServer.getSpec().getRuntime().getTemplates().getContainer().setImagePullPolicy(imagePullPolicy);
+        client.resource(debeziumServer).create();
+        await().ignoreException(NullPointerException.class).atMost(2, TimeUnit.MINUTES).untilAsserted(() -> {
+            final var deployment = client.apps().deployments()
+                    .inNamespace(debeziumServer.getMetadata().getNamespace())
+                    .withName(debeziumServer.getMetadata().getName())
+                    .get();
+            assertThat(deployment).isNotNull();
+
+            final var maybeContainer = deployment.getSpec().getTemplate().getSpec().getContainers()
+                    .stream()
+                    .findFirst();
+            assertThat(maybeContainer).isPresent();
+            assertThat(maybeContainer.get().getImagePullPolicy()).isEqualTo(imagePullPolicy.getValue());
         });
     }
 }

--- a/debezium-operator-core/src/test/java/io/debezium/operator/core/DebeziumServerReconcilerTest.java
+++ b/debezium-operator-core/src/test/java/io/debezium/operator/core/DebeziumServerReconcilerTest.java
@@ -47,6 +47,8 @@ public class DebeziumServerReconcilerTest {
 
     @Test
     void shouldReconcileDebeziumServer() {
+        final String imagePullPolicy = "IfNotPresent";
+        debeziumServer.getSpec().getRuntime().getTemplates().getContainer().setImagePullPolicy(imagePullPolicy);
         client.resource(debeziumServer).create();
         await().ignoreException(NullPointerException.class).atMost(2, TimeUnit.MINUTES).untilAsserted(() -> {
             // check config map
@@ -78,6 +80,7 @@ public class DebeziumServerReconcilerTest {
             assertThat(container.getImage()).isEqualTo(debeziumServer.getSpec().getImage());
             assertThat(container.getLivenessProbe()).isNotNull();
             assertThat(container.getReadinessProbe()).isNotNull();
+            assertThat(container.getImagePullPolicy()).isEqualTo(imagePullPolicy);
             assertThat(container.getVolumeMounts()).hasSize(2);
             assertThat(container.getVolumeMounts()).anyMatch(mount -> mount.getName().equals(DeploymentDependent.CONFIG_VOLUME_NAME) &&
                     mount.getMountPath().equals(DeploymentDependent.CONFIG_FILE_PATH) &&

--- a/docs/reference.adoc
+++ b/docs/reference.adoc
@@ -53,7 +53,7 @@ Used in: <<debezium-operator-schema-reference-templates, `+Templates+`>>
 | [[debezium-operator-schema-reference-containertemplate-resources]]<<debezium-operator-schema-reference-containertemplate-resources, `+resources+`>> | https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#resourcerequirements-v1-core[`+ResourceRequirements+`] |  | CPU and memory resource requirements.
 | [[debezium-operator-schema-reference-containertemplate-securitycontext]]<<debezium-operator-schema-reference-containertemplate-securitycontext, `+securityContext+`>> | https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#securitycontext-v1-core[`+SecurityContext+`] |  | Container security context.
 | [[debezium-operator-schema-reference-containertemplate-probes]]<<debezium-operator-schema-reference-containertemplate-probes, `+probes+`>> | <<debezium-operator-schema-reference-probes, `+Probes+`>> |  | Container probes configuration.
-| [[debezium-operator-schema-reference-containertemplate-imagepullpolicy]]<<debezium-operator-schema-reference-containertemplate-imagepullpolicy, `+imagePullPolicy+`>> | String |  | Image pull policy for the container.
+| [[debezium-operator-schema-reference-containertemplate-imagepullpolicy]]<<debezium-operator-schema-reference-containertemplate-imagepullpolicy, `+imagePullPolicy+`>> | always,if_not_present,never |  | Image pull policy for the container.
 |===
 
 [#debezium-operator-schema-reference-customstore]

--- a/docs/reference.adoc
+++ b/docs/reference.adoc
@@ -53,6 +53,7 @@ Used in: <<debezium-operator-schema-reference-templates, `+Templates+`>>
 | [[debezium-operator-schema-reference-containertemplate-resources]]<<debezium-operator-schema-reference-containertemplate-resources, `+resources+`>> | https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#resourcerequirements-v1-core[`+ResourceRequirements+`] |  | CPU and memory resource requirements.
 | [[debezium-operator-schema-reference-containertemplate-securitycontext]]<<debezium-operator-schema-reference-containertemplate-securitycontext, `+securityContext+`>> | https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#securitycontext-v1-core[`+SecurityContext+`] |  | Container security context.
 | [[debezium-operator-schema-reference-containertemplate-probes]]<<debezium-operator-schema-reference-containertemplate-probes, `+probes+`>> | <<debezium-operator-schema-reference-probes, `+Probes+`>> |  | Container probes configuration.
+| [[debezium-operator-schema-reference-containertemplate-imagepullpolicy]]<<debezium-operator-schema-reference-containertemplate-imagepullpolicy, `+imagePullPolicy+`>> | String |  | Image pull policy for the container.
 |===
 
 [#debezium-operator-schema-reference-customstore]

--- a/k8/debeziumservers.debezium.io-v1.yml
+++ b/k8/debeziumservers.debezium.io-v1.yml
@@ -928,6 +928,9 @@ spec:
                       container:
                         description: "Container template"
                         properties:
+                          imagePullPolicy:
+                            description: "Image pull policy for the container."
+                            type: "string"
                           probes:
                             description: "Container probes configuration."
                             properties:

--- a/k8/debeziumservers.debezium.io-v1.yml
+++ b/k8/debeziumservers.debezium.io-v1.yml
@@ -930,6 +930,10 @@ spec:
                         properties:
                           imagePullPolicy:
                             description: "Image pull policy for the container."
+                            enum:
+                            - "Always"
+                            - "IfNotPresent"
+                            - "Never"
                             type: "string"
                           probes:
                             description: "Container probes configuration."


### PR DESCRIPTION
<!-- Make sure all your commits are signed before submitting your pull request -->
<!-- Run `git commit -s` to sign off your commits to satisfy the DCO check -->
<!-- Ensure your commit messages start with your GitHub issue, e.g., debezium/dbz#<issue_number> -->
Fixes debezium/dbz#1591

## Description
Adds support for configuring `imagePullPolicy` on the DebeziumServer container template, so users can override the default kubelet image pull behavior.

## PR Checklist
<!-- Please review the following checklist and mark items with an 'x' before submitting your pull request. -->
- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`
