### PR TITLE
debezium/dbz#1896 Add support for enabling and configuring Otel agent

### DIFF
--- a/debezium-operator-api/src/main/java/io/debezium/operator/api/model/runtime/metrics/Metrics.java
+++ b/debezium-operator-api/src/main/java/io/debezium/operator/api/model/runtime/metrics/Metrics.java
@@ -17,11 +17,22 @@ public class Metrics {
     @JsonPropertyDescription("Prometheus JMX exporter configuration")
     private JmxExporter jmxExporter = new JmxExporter();
 
+    @JsonPropertyDescription("OpenTelemetry configuration")
+    private OpenTelemetry openTelemetry = new OpenTelemetry();
+
     public JmxExporter getJmxExporter() {
         return jmxExporter;
     }
 
     public void setJmxExporter(JmxExporter jmxExporter) {
         this.jmxExporter = jmxExporter;
+    }
+
+    public OpenTelemetry getOpenTelemetry() {
+        return openTelemetry;
+    }
+
+    public void setOpenTelemetry(OpenTelemetry openTelemetry) {
+        this.openTelemetry = openTelemetry;
     }
 }

--- a/debezium-operator-api/src/main/java/io/debezium/operator/api/model/runtime/metrics/OpenTelemetry.java
+++ b/debezium-operator-api/src/main/java/io/debezium/operator/api/model/runtime/metrics/OpenTelemetry.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.operator.api.model.runtime.metrics;
+
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+
+import io.debezium.operator.docs.annotations.Documented;
+import io.sundr.builder.annotations.Buildable;
+
+@Documented
+@Buildable(editableEnabled = false, builderPackage = "io.fabric8.kubernetes.api.builder", lazyCollectionInitEnabled = false)
+public class OpenTelemetry {
+
+    @JsonPropertyDescription("Enables OpenTelemetry")
+    private boolean enabled = false;
+
+    @JsonPropertyDescription("OpenTelemetry collector configuration")
+    private OtelCollector collector = new OtelCollector();
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    public OtelCollector getCollector() {
+        return collector;
+    }
+
+    public void setCollector(OtelCollector collector) {
+        this.collector = collector;
+    }
+}

--- a/debezium-operator-api/src/main/java/io/debezium/operator/api/model/runtime/metrics/OtelCollector.java
+++ b/debezium-operator-api/src/main/java/io/debezium/operator/api/model/runtime/metrics/OtelCollector.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.operator.api.model.runtime.metrics;
+
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+
+import io.debezium.operator.docs.annotations.Documented;
+import io.sundr.builder.annotations.Buildable;
+
+@Documented
+@Buildable(editableEnabled = false, builderPackage = "io.fabric8.kubernetes.api.builder", lazyCollectionInitEnabled = false)
+public class OtelCollector {
+
+    @JsonPropertyDescription("OTLP collector endpoint")
+    private String endpoint;
+
+    public String getEndpoint() {
+        return endpoint;
+    }
+
+    public void setEndpoint(String endpoint) {
+        this.endpoint = endpoint;
+    }
+}

--- a/debezium-operator-core/src/main/java/io/debezium/operator/core/dependent/DeploymentDependent.java
+++ b/debezium-operator-core/src/main/java/io/debezium/operator/core/dependent/DeploymentDependent.java
@@ -73,6 +73,16 @@ public class DeploymentDependent extends CRUDKubernetesDependentResource<Deploym
     public static final int DEFAULT_HTTP_PORT = 8080;
     public static final int DEFAULT_JMX_EXPORTER_METRICS_PORT = 9090;
     public static final String JMX_EXPORTER_METRICS_PORT_NAME = "metrics-jmx";
+    public static final String DEFAULT_OTEL_ENDPOINT = "http://localhost:4318";
+    public static final String DEFAULT_OTEL_JMX_CONFIG = "config/debezium-jmx-config.yaml";
+    public static final String OTEL_ENABLED_ENV = "OTEL_ENABLED";
+    public static final String OTEL_SDK_DISABLED_ENV = "OTEL_SDK_DISABLED";
+    public static final String OTEL_EXPORTER_OTLP_ENDPOINT_ENV = "OTEL_EXPORTER_OTLP_ENDPOINT";
+    public static final String OTEL_METRICS_EXPORTER_ENV = "OTEL_METRICS_EXPORTER";
+    public static final String OTEL_SERVICE_NAME_ENV = "OTEL_SERVICE_NAME";
+    public static final String OTEL_RESOURCE_ATTRIBUTES_ENV = "OTEL_RESOURCE_ATTRIBUTES";
+    public static final String OTEL_JMX_CONFIG_ENV = "OTEL_JMX_CONFIG";
+    public static final String OTEL_RESOURCE_ATTRIBUTES_FORMAT = "service.name=%s,debezium.connector.type=%s";
     private static final String CONFIG_MD5_ANNOTATION = "debezium.io/server-config-md5";
 
     @ConfigProperty(name = "debezium.server.image.name", defaultValue = DEFAULT_IMAGE)
@@ -343,6 +353,7 @@ public class DeploymentDependent extends CRUDKubernetesDependentResource<Deploym
         addStorageVolumeMountsToContainer(storage, container);
         addJmxConfigurationToContainer(jmx, container);
         addMetricConfigurationToContainer(metrics, container);
+        addOpenTelemetryConfigurationToContainer(primary, container);
         return container;
     }
 
@@ -499,6 +510,48 @@ public class DeploymentDependent extends CRUDKubernetesDependentResource<Deploym
 
         // If JAVA_OPTS is already set (e.g. from container template) we don't want to override it
         mergeJavaOptsEnvVar(opts, container);
+    }
+
+    private void addOpenTelemetryConfigurationToContainer(DebeziumServer primary, Container container) {
+        var otel = primary.getSpec().getRuntime().getMetrics().getOpenTelemetry();
+
+        if (!otel.isEnabled()) {
+            return;
+        }
+
+        var name = primary.getMetadata().getName();
+        var connectorType = extractConnectorType(primary.getSpec().getSource().getSourceClass());
+        var endpoint = Optional.ofNullable(otel.getCollector().getEndpoint())
+                .filter(e -> !e.isBlank())
+                .orElse(DEFAULT_OTEL_ENDPOINT);
+        var resourceAttributes = OTEL_RESOURCE_ATTRIBUTES_FORMAT.formatted(name, connectorType);
+
+        addEnvVarIfAbsent(container, OTEL_ENABLED_ENV, "true");
+        addEnvVarIfAbsent(container, OTEL_SDK_DISABLED_ENV, "false");
+        addEnvVarIfAbsent(container, OTEL_EXPORTER_OTLP_ENDPOINT_ENV, endpoint);
+        addEnvVarIfAbsent(container, OTEL_METRICS_EXPORTER_ENV, "otlp");
+        addEnvVarIfAbsent(container, OTEL_SERVICE_NAME_ENV, name);
+        addEnvVarIfAbsent(container, OTEL_RESOURCE_ATTRIBUTES_ENV, resourceAttributes);
+        addEnvVarIfAbsent(container, OTEL_JMX_CONFIG_ENV, DEFAULT_OTEL_JMX_CONFIG);
+    }
+
+    private void addEnvVarIfAbsent(Container container, String name, String value) {
+        var exists = container.getEnv().stream()
+                .anyMatch(envVar -> name.equals(envVar.getName()));
+        if (!exists) {
+            container.getEnv().add(new EnvVar(name, value, null));
+        }
+    }
+
+    static String extractConnectorType(String sourceClass) {
+        if (sourceClass == null || sourceClass.isBlank()) {
+            return "unknown";
+        }
+        var parts = sourceClass.split("\\.");
+        if (parts.length < 2) {
+            return "unknown";
+        }
+        return parts[parts.length - 2];
     }
 
     /**

--- a/debezium-operator-core/src/test/java/io/debezium/operator/core/OpenTelemetryReconcilerTest.java
+++ b/debezium-operator-core/src/test/java/io/debezium/operator/core/OpenTelemetryReconcilerTest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.operator.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.debezium.operator.api.model.DebeziumServer;
+import io.debezium.operator.api.model.runtime.metrics.OtelCollectorBuilder;
+import io.fabric8.kubernetes.api.model.EnvVar;
+import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.javaoperatorsdk.operator.ReconcilerUtilsInternal;
+import io.quarkus.kubernetes.client.runtime.internal.KubernetesClientUtils;
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+public class OpenTelemetryReconcilerTest {
+
+    public static final String DS_NAME = "test-ds-otel";
+
+    KubernetesClient client = KubernetesClientUtils.createClient();
+    DebeziumServer debeziumServer;
+
+    @BeforeEach
+    void before() {
+        debeziumServer = ReconcilerUtilsInternal.loadYaml(
+                DebeziumServer.class, OpenTelemetryReconcilerTest.class, "/test-samples/ds-postgres-minimal.yml");
+        final var metadata = new ObjectMetaBuilder()
+                .withName(DS_NAME)
+                .withNamespace(client.getNamespace())
+                .build();
+        debeziumServer.setMetadata(metadata);
+    }
+
+    @AfterEach
+    void after() {
+        client.resource(debeziumServer).delete();
+    }
+
+    @Test
+    void shouldNotSetOtelEnvVarsWhenDisabled() {
+        client.resource(debeziumServer).create();
+        await().ignoreException(NullPointerException.class).atMost(2, TimeUnit.MINUTES).untilAsserted(() -> {
+            final var deployment = client.apps().deployments()
+                    .inNamespace(debeziumServer.getMetadata().getNamespace())
+                    .withName(DS_NAME)
+                    .get();
+            assertThat(deployment).isNotNull();
+
+            final var container = deployment.getSpec().getTemplate().getSpec().getContainers().get(0);
+            assertThat(container.getEnv())
+                    .extracting(EnvVar::getName)
+                    .doesNotContain("OTEL_ENABLED", "OTEL_SDK_DISABLED", "OTEL_SERVICE_NAME");
+        });
+    }
+
+    @Test
+    void shouldSetOtelEnvVarsWhenEnabled() {
+        debeziumServer.getSpec().getRuntime().getMetrics().getOpenTelemetry().setEnabled(true);
+
+        client.resource(debeziumServer).create();
+        await().ignoreException(NullPointerException.class).atMost(2, TimeUnit.MINUTES).untilAsserted(() -> {
+            final var deployment = client.apps().deployments()
+                    .inNamespace(debeziumServer.getMetadata().getNamespace())
+                    .withName(DS_NAME)
+                    .get();
+            assertThat(deployment).isNotNull();
+
+            final var container = deployment.getSpec().getTemplate().getSpec().getContainers().get(0);
+            var envVars = container.getEnv();
+
+            assertThat(envVars).anyMatch(e -> "OTEL_ENABLED".equals(e.getName()) && "true".equals(e.getValue()));
+            assertThat(envVars).anyMatch(e -> "OTEL_SDK_DISABLED".equals(e.getName()) && "false".equals(e.getValue()));
+            assertThat(envVars).anyMatch(e -> "OTEL_METRICS_EXPORTER".equals(e.getName()) && "otlp".equals(e.getValue()));
+            assertThat(envVars).anyMatch(e -> "OTEL_SERVICE_NAME".equals(e.getName()) && DS_NAME.equals(e.getValue()));
+            assertThat(envVars).anyMatch(e -> "OTEL_EXPORTER_OTLP_ENDPOINT".equals(e.getName())
+                    && "http://localhost:4318".equals(e.getValue()));
+            assertThat(envVars).anyMatch(e -> "OTEL_JMX_CONFIG".equals(e.getName())
+                    && "config/debezium-jmx-config.yaml".equals(e.getValue()));
+            assertThat(envVars).anyMatch(e -> "OTEL_RESOURCE_ATTRIBUTES".equals(e.getName())
+                    && e.getValue().contains("service.name=" + DS_NAME)
+                    && e.getValue().contains("debezium.connector.type=postgresql"));
+        });
+    }
+
+    @Test
+    void shouldUseCustomEndpointWhenProvided() {
+        var otel = debeziumServer.getSpec().getRuntime().getMetrics().getOpenTelemetry();
+        otel.setEnabled(true);
+        otel.setCollector(new OtelCollectorBuilder()
+                .withEndpoint("http://my-collector:4317")
+                .build());
+
+        client.resource(debeziumServer).create();
+        await().ignoreException(NullPointerException.class).atMost(2, TimeUnit.MINUTES).untilAsserted(() -> {
+            final var deployment = client.apps().deployments()
+                    .inNamespace(debeziumServer.getMetadata().getNamespace())
+                    .withName(DS_NAME)
+                    .get();
+            assertThat(deployment).isNotNull();
+
+            final var container = deployment.getSpec().getTemplate().getSpec().getContainers().get(0);
+            assertThat(container.getEnv())
+                    .anyMatch(e -> "OTEL_EXPORTER_OTLP_ENDPOINT".equals(e.getName())
+                            && "http://my-collector:4317".equals(e.getValue()));
+        });
+    }
+}

--- a/debezium-operator-core/src/test/java/io/debezium/operator/core/dependent/DeploymentDependentTest.java
+++ b/debezium-operator-core/src/test/java/io/debezium/operator/core/dependent/DeploymentDependentTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.operator.core.dependent;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+public class DeploymentDependentTest {
+
+    @ParameterizedTest
+    @CsvSource({
+            "io.debezium.connector.postgresql.PostgresConnector, postgresql",
+            "io.debezium.connector.mysql.MySqlConnector, mysql",
+            "io.debezium.connector.mongodb.MongoDbConnector, mongodb",
+            "io.debezium.connector.sqlserver.SqlServerConnector, sqlserver",
+            "io.debezium.connector.oracle.OracleConnector, oracle",
+    })
+    void shouldExtractConnectorType(String sourceClass, String expectedType) {
+        assertThat(DeploymentDependent.extractConnectorType(sourceClass)).isEqualTo(expectedType);
+    }
+
+    @Test
+    void shouldReturnUnknownForNullSourceClass() {
+        assertThat(DeploymentDependent.extractConnectorType(null)).isEqualTo("unknown");
+    }
+
+    @Test
+    void shouldReturnUnknownForBlankSourceClass() {
+        assertThat(DeploymentDependent.extractConnectorType("")).isEqualTo("unknown");
+        assertThat(DeploymentDependent.extractConnectorType("  ")).isEqualTo("unknown");
+    }
+
+    @Test
+    void shouldReturnUnknownForSingleSegmentClass() {
+        assertThat(DeploymentDependent.extractConnectorType("PostgresConnector")).isEqualTo("unknown");
+    }
+}

--- a/docs/reference.adoc
+++ b/docs/reference.adoc
@@ -369,6 +369,7 @@ Used in: <<debezium-operator-schema-reference-runtime, `+Runtime+`>>
 |===
 | Property | Type | Default | Description
 | [[debezium-operator-schema-reference-metrics-jmxexporter]]<<debezium-operator-schema-reference-metrics-jmxexporter, `+jmxExporter+`>> | <<debezium-operator-schema-reference-jmxexporter, `+JmxExporter+`>> |  | Prometheus JMX exporter configuration
+| [[debezium-operator-schema-reference-metrics-opentelemetry]]<<debezium-operator-schema-reference-metrics-opentelemetry, `+openTelemetry+`>> | <<debezium-operator-schema-reference-opentelemetry, `+OpenTelemetry+`>> |  | OpenTelemetry configuration
 |===
 
 [#debezium-operator-schema-reference-offset]
@@ -388,6 +389,31 @@ Used in: <<debezium-operator-schema-reference-source, `+Source+`>>
 | [[debezium-operator-schema-reference-offset-configmap]]<<debezium-operator-schema-reference-offset-configmap, `+configMap+`>> | <<debezium-operator-schema-reference-configmapoffsetstore, `+ConfigMapOffsetStore+`>> |  | Config map backed offset store configuration
 | [[debezium-operator-schema-reference-offset-store]]<<debezium-operator-schema-reference-offset-store, `+store+`>> | <<debezium-operator-schema-reference-customstore, `+CustomStore+`>> |  | Arbitrary offset store configuration
 | [[debezium-operator-schema-reference-offset-flushms]]<<debezium-operator-schema-reference-offset-flushms, `+flushMs+`>> | long | 60000 | Interval at which to try commiting offsets
+|===
+
+[#debezium-operator-schema-reference-opentelemetry]
+==== OpenTelemetry Schema Reference
+Used in: <<debezium-operator-schema-reference-metrics, `+Metrics+`>>
+
+
+.OpenTelemetry properties
+[cols="20%a,25%s,15%a,40%a",options="header"]
+|===
+| Property | Type | Default | Description
+| [[debezium-operator-schema-reference-opentelemetry-enabled]]<<debezium-operator-schema-reference-opentelemetry-enabled, `+enabled+`>> | boolean |  | Enables OpenTelemetry
+| [[debezium-operator-schema-reference-opentelemetry-collector]]<<debezium-operator-schema-reference-opentelemetry-collector, `+collector+`>> | <<debezium-operator-schema-reference-otelcollector, `+OtelCollector+`>> |  | OpenTelemetry collector configuration
+|===
+
+[#debezium-operator-schema-reference-otelcollector]
+==== OtelCollector Schema Reference
+Used in: <<debezium-operator-schema-reference-opentelemetry, `+OpenTelemetry+`>>
+
+
+.OtelCollector properties
+[cols="20%a,25%s,15%a,40%a",options="header"]
+|===
+| Property | Type | Default | Description
+| [[debezium-operator-schema-reference-otelcollector-endpoint]]<<debezium-operator-schema-reference-otelcollector-endpoint, `+endpoint+`>> | String |  | OTLP collector endpoint
 |===
 
 [#debezium-operator-schema-reference-podtemplate]

--- a/examples/postgres/020_debezium-server-otel.yml
+++ b/examples/postgres/020_debezium-server-otel.yml
@@ -1,0 +1,52 @@
+apiVersion: debezium.io/v1alpha1
+kind: DebeziumServer
+metadata:
+  name: my-debezium
+spec:
+  image: quay.io/debezium/server:nightly
+  quarkus:
+    config:
+      log.console.json: false
+      kubernetes-config.enabled: true
+      kubernetes-config.secrets: postgresql-credentials
+  runtime:
+    api:
+      enabled: true
+    metrics:
+      openTelemetry:
+        enabled: true
+    environment:
+      vars:
+        - name: OTEL_METRICS_EXPORTER
+          value: logging
+        - name: OTEL_TRACES_EXPORTER
+          value: none
+        - name: OTEL_LOGS_EXPORTER
+          value: none
+        - name: OTEL_METRIC_EXPORT_INTERVAL
+          value: "10000"
+  sink:
+    type: jdbc
+    config:
+      connection.url: jdbc:postgresql://postgresql:5432/debezium
+      connection.username: debezium
+      connection.password: debezium
+      insert.mode: upsert
+      primary.key.mode: record_key
+      schema.evolution: basic
+      table.name.format: $${topic}
+  source:
+    class: io.debezium.connector.postgresql.PostgresConnector
+    offset:
+      memory: { }
+    schemaHistory:
+      memory: { }
+    config:
+      database.hostname: postgresql
+      database.port: 5432
+      database.user: ${POSTGRES_USER}
+      database.password: ${POSTGRES_PASSWORD}
+      database.dbname: ${POSTGRES_DB}
+      topic.prefix: inventory
+      schema.include.list: inventory
+      table.exclude.list: inventory.geom

--- a/k8/debeziumservers.debezium.io-v1.yml
+++ b/k8/debeziumservers.debezium.io-v1.yml
@@ -195,6 +195,20 @@ spec:
                             description: "Enables JMX Prometheus exporter"
                             type: "boolean"
                         type: "object"
+                      openTelemetry:
+                        description: "OpenTelemetry configuration"
+                        properties:
+                          collector:
+                            description: "OpenTelemetry collector configuration"
+                            properties:
+                              endpoint:
+                                description: "OTLP collector endpoint"
+                                type: "string"
+                            type: "object"
+                          enabled:
+                            description: "Enables OpenTelemetry"
+                            type: "boolean"
+                        type: "object"
                     type: "object"
                   serviceAccount:
                     description: "An existing service account used to run the Debezium\

--- a/k8/kubernetes.yml
+++ b/k8/kubernetes.yml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   annotations:
-    app.quarkus.io/quarkus-version: 3.35.2
+    app.quarkus.io/quarkus-version: 3.35.3
   labels:
     app.kubernetes.io/name: debezium-operator
     app.kubernetes.io/managed-by: quarkus
@@ -158,7 +158,7 @@ apiVersion: v1
 kind: Service
 metadata:
   annotations:
-    app.quarkus.io/quarkus-version: 3.35.2
+    app.quarkus.io/quarkus-version: 3.35.3
   labels:
     app.kubernetes.io/name: debezium-operator
     app.kubernetes.io/managed-by: quarkus
@@ -177,7 +177,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    app.quarkus.io/quarkus-version: 3.35.2
+    app.quarkus.io/quarkus-version: 3.35.3
   labels:
     app.kubernetes.io/name: debezium-operator
     app.kubernetes.io/managed-by: quarkus
@@ -190,7 +190,7 @@ spec:
   template:
     metadata:
       annotations:
-        app.quarkus.io/quarkus-version: 3.35.2
+        app.quarkus.io/quarkus-version: 3.35.3
       labels:
         app.kubernetes.io/managed-by: quarkus
         app.kubernetes.io/name: debezium-operator

--- a/systemtests/src/test/java/io/debezium/operator/systemtests/OpenTelemetryTest.java
+++ b/systemtests/src/test/java/io/debezium/operator/systemtests/OpenTelemetryTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.operator.systemtests;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.debezium.operator.api.model.DebeziumServer;
+import io.debezium.operator.api.model.runtime.metrics.OtelCollectorBuilder;
+import io.debezium.operator.systemtests.resources.NamespaceHolder;
+import io.debezium.operator.systemtests.resources.operator.DebeziumOperatorBundleResource;
+import io.debezium.operator.systemtests.resources.server.DebeziumServerGenerator;
+import io.fabric8.kubernetes.api.model.apps.Deployment;
+import io.skodjob.testframe.resources.KubeResourceManager;
+
+public class OpenTelemetryTest extends TestBase {
+    private final Logger logger = LoggerFactory.getLogger(this.getClass());
+
+    @Test
+    void testOpenTelemetryEnvVarsAppliedToDeployment() {
+        String namespace = NamespaceHolder.INSTANCE.getCurrentNamespace();
+        DebeziumOperatorBundleResource operatorBundleResource = new DebeziumOperatorBundleResource();
+        operatorBundleResource.configureAsDefault(namespace);
+        logger.info("Deploying Operator");
+        operatorBundleResource.deploy();
+
+        DebeziumServer server = DebeziumServerGenerator.generateDefaultMysqlToRedis(namespace);
+        server.getSpec().getRuntime().getMetrics().getOpenTelemetry().setEnabled(true);
+
+        logger.info("Deploying Debezium Server with OpenTelemetry enabled");
+        KubeResourceManager.getInstance().createResourceWithWait(server);
+        assertStreamingWorks();
+
+        Deployment deployment = KubeResourceManager.getKubeClient().getClient()
+                .apps().deployments()
+                .inNamespace(namespace)
+                .withName(server.getMetadata().getName())
+                .get();
+
+        assertThat(deployment).isNotNull();
+
+        var container = deployment.getSpec().getTemplate().getSpec().getContainers().get(0);
+        var envVars = container.getEnv();
+
+        assertThat(envVars).anyMatch(e -> "OTEL_ENABLED".equals(e.getName()) && "true".equals(e.getValue()));
+        assertThat(envVars).anyMatch(e -> "OTEL_SDK_DISABLED".equals(e.getName()) && "false".equals(e.getValue()));
+        assertThat(envVars).anyMatch(e -> "OTEL_METRICS_EXPORTER".equals(e.getName()) && "otlp".equals(e.getValue()));
+        assertThat(envVars).anyMatch(e -> "OTEL_JMX_CONFIG".equals(e.getName()));
+        assertThat(envVars).anyMatch(e -> "OTEL_SERVICE_NAME".equals(e.getName())
+                && server.getMetadata().getName().equals(e.getValue()));
+        assertThat(envVars).anyMatch(e -> "OTEL_EXPORTER_OTLP_ENDPOINT".equals(e.getName()));
+        assertThat(envVars).anyMatch(e -> "OTEL_RESOURCE_ATTRIBUTES".equals(e.getName())
+                && e.getValue().contains("service.name=" + server.getMetadata().getName())
+                && e.getValue().contains("debezium.connector.type=mysql"));
+    }
+
+    @Test
+    void testOpenTelemetryWithCustomEndpoint() {
+        String namespace = NamespaceHolder.INSTANCE.getCurrentNamespace();
+        DebeziumOperatorBundleResource operatorBundleResource = new DebeziumOperatorBundleResource();
+        operatorBundleResource.configureAsDefault(namespace);
+        logger.info("Deploying Operator");
+        operatorBundleResource.deploy();
+
+        String customEndpoint = "http://otel-collector:4317";
+        DebeziumServer server = DebeziumServerGenerator.generateDefaultMysqlToRedis(namespace);
+        var otel = server.getSpec().getRuntime().getMetrics().getOpenTelemetry();
+        otel.setEnabled(true);
+        otel.setCollector(new OtelCollectorBuilder()
+                .withEndpoint(customEndpoint)
+                .build());
+
+        logger.info("Deploying Debezium Server with custom OpenTelemetry endpoint");
+        KubeResourceManager.getInstance().createResourceWithWait(server);
+        assertStreamingWorks();
+
+        Deployment deployment = KubeResourceManager.getKubeClient().getClient()
+                .apps().deployments()
+                .inNamespace(namespace)
+                .withName(server.getMetadata().getName())
+                .get();
+
+        assertThat(deployment).isNotNull();
+
+        var container = deployment.getSpec().getTemplate().getSpec().getContainers().get(0);
+        assertThat(container.getEnv())
+                .anyMatch(e -> "OTEL_EXPORTER_OTLP_ENDPOINT".equals(e.getName())
+                        && customEndpoint.equals(e.getValue()));
+    }
+}


### PR DESCRIPTION
Fixes debezium/dbz#1896

## Description
This pull request introduces OpenTelemetry support to the Debezium Operator, allowing users to enable and configure OpenTelemetry metrics export for DebeziumServer deployments. It adds new API model classes, updates the CRD schema and documentation, and provides integration and unit tests to verify the new functionality. Additionally, an example manifest is included to demonstrate usage.

## PR Checklist
- [X] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [X] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [X] One feature/change per PR unless tightly coupled
- [X] Do a rebase on upstream `main`
