### PR TITLE
debezium/dbz-1918 Add OpenTelemetry metrics configuration

### DIFF
--- a/debezium-operator-core/pom.xml
+++ b/debezium-operator-core/pom.xml
@@ -37,6 +37,10 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-arc</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-opentelemetry</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>io.quarkiverse.helm</groupId>

--- a/debezium-operator-core/pom.xml
+++ b/debezium-operator-core/pom.xml
@@ -41,6 +41,11 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-opentelemetry</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-sdk-testing</artifactId>
+            <scope>test</scope>
+        </dependency>
 
         <dependency>
             <groupId>io.quarkiverse.helm</groupId>

--- a/debezium-operator-core/src/main/resources/application.properties
+++ b/debezium-operator-core/src/main/resources/application.properties
@@ -4,3 +4,7 @@ quarkus.application.name=debezium-operator
 
 # Quarkus helm configurations
 quarkus.helm.values."app.envs.QUARKUS_OPERATOR_SDK_CONTROLLERS_DEBEZIUMSERVER_NAMESPACES".value=JOSDK_ALL_NAMESPACES
+# OpenTelemetry Metrics (Tech Preview - must be enabled at build time)
+quarkus.otel.metrics.enabled=true
+quarkus.otel.instrument.jvm-metrics=true
+quarkus.helm.values."app.envs.QUARKUS_OTEL_EXPORTER_OTLP_ENDPOINT".value=http://otel-collector:4317

--- a/debezium-operator-core/src/main/resources/application.properties
+++ b/debezium-operator-core/src/main/resources/application.properties
@@ -7,4 +7,11 @@ quarkus.helm.values."app.envs.QUARKUS_OPERATOR_SDK_CONTROLLERS_DEBEZIUMSERVER_NA
 # OpenTelemetry Metrics (Tech Preview - must be enabled at build time)
 quarkus.otel.metrics.enabled=true
 quarkus.otel.instrument.jvm-metrics=true
+quarkus.kubernetes.env.vars.QUARKUS_OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4317
 quarkus.helm.values."app.envs.QUARKUS_OTEL_EXPORTER_OTLP_ENDPOINT".value=http://otel-collector:4317
+
+quarkus.kubernetes.env.vars.QUARKUS_OTEL_METRIC_EXPORT_INTERVAL=60000
+quarkus.helm.values."app.envs.QUARKUS_OTEL_METRIC_EXPORT_INTERVAL".value=60000
+
+quarkus.kubernetes.env.vars.QUARKUS_OTEL_RESOURCE_ATTRIBUTES=service.name=debezium-operator
+quarkus.helm.values."app.envs.QUARKUS_OTEL_RESOURCE_ATTRIBUTES".value=service.name=debezium-operator

--- a/debezium-operator-core/src/test/java/io/debezium/operator/core/JvmMetricsIT.java
+++ b/debezium-operator-core/src/test/java/io/debezium/operator/core/JvmMetricsIT.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.operator.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import java.util.List;
+import java.util.Map;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+
+import io.opentelemetry.sdk.metrics.data.MetricData;
+import io.opentelemetry.sdk.testing.exporter.InMemoryMetricExporter;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+
+@QuarkusTest
+@TestProfile(JvmMetricsIT.OtelMetricsProfile.class)
+public class JvmMetricsIT {
+
+    public static class OtelMetricsProfile implements QuarkusTestProfile {
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            return Map.of(
+                    "quarkus.otel.metrics.enabled", "true",
+                    "quarkus.otel.instrument.jvm-metrics", "true",
+                    "quarkus.otel.metric.export.interval", "500ms");
+        }
+    }
+
+    @jakarta.enterprise.inject.Produces
+    @jakarta.inject.Singleton
+    public static InMemoryMetricExporter inMemoryMetricExporter() {
+        return InMemoryMetricExporter.create();
+    }
+
+    @Inject
+    InMemoryMetricExporter metricExporter;
+
+    @Test
+    public void shouldExposeJvmMetrics() {
+        await().atMost(60, java.util.concurrent.TimeUnit.SECONDS).untilAsserted(() -> {
+            List<MetricData> metrics = metricExporter.getFinishedMetricItems();
+            assertThat(metrics).isNotEmpty();
+
+            boolean hasJvmMetrics = metrics.stream()
+                    .anyMatch(m -> m.getName().startsWith("jvm.memory") || m.getName().startsWith("process.runtime.jvm"));
+
+            assertThat(hasJvmMetrics)
+                    .withFailMessage("Expected JVM metrics (starting with jvm.memory or process.runtime.jvm) to be collected but found none.")
+                    .isTrue();
+        });
+    }
+}


### PR DESCRIPTION
<!-- Make sure all your commits are signed before submitting your pull request -->
<!-- Run `git commit -s` to sign off your commits to satisfy the DCO check -->
<!-- Ensure your commit messages start with your GitHub issue, e.g., debezium/dbz#<issue_number> -->
Fixes debezium/dbz#1918

## Description
<!-- Briefly describe your changes here. -->

This PR addresses the Operator portion of #1918 by adding OpenTelemetry support to the Debezium Operator.

Following the team's preference for OTel monitoring, we have added the `quarkus-opentelemetry` extension to the `debezium-operator-core`. This enables native distributed tracing and telemetry data to be pushed directly via OTLP, matching the platform's Conductor implementation. 

**Companion PR**: Please see the companion PR in the `debezium-platform` repository for the Conductor updates and Helm chart deployment integrations: debezium/debezium-platform#405

Fixes #1918 (Part 2/2)

## PR Checklist
<!-- Please review the following checklist and mark items with an 'x' before submitting your pull request. -->
- [X] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [X] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [X] One feature/change per PR unless tightly coupled
- [X] Do a rebase on upstream `main`
