### PR TITLE
debezium/dbz#2181 Escape $ to avoid SmallRye property expression

### DIFF
--- a/examples/postgres/010_debezium-server-ephemeral.yml
+++ b/examples/postgres/010_debezium-server-ephemeral.yml
@@ -27,8 +27,8 @@ spec:
     config:
       database.hostname: postgresql
       database.port: 5432
-      database.user: ${POSTGRES_USER}
-      database.password: ${POSTGRES_PASSWORD}
-      database.dbname: ${POSTGRES_DB}
+      database.user: $${POSTGRES_USER}
+      database.password: $${POSTGRES_PASSWORD}
+      database.dbname: $${POSTGRES_DB}
       topic.prefix: inventory
       schema.include.list: inventory

--- a/systemtests/src/test/resources/server/default-server.yaml
+++ b/systemtests/src/test/resources/server/default-server.yaml
@@ -22,8 +22,8 @@ spec:
       database.history: io.debezium.relational.history.FileDatabaseHistory
       database.hostname: mysql-dbz-svc
       database.port: 3306
-      database.user: ${DBZ_USER}
-      database.password: ${DBZ_PASSWORD}
+      database.user: $${DBZ_USER}
+      database.password: $${DBZ_PASSWORD}
       database.server.id: 32268
       topic.prefix: inventory
       schema.history.internal: io.debezium.storage.redis.history.RedisSchemaHistory


### PR DESCRIPTION
<!-- Make sure all your commits are signed before submitting your pull request -->
<!-- Run `git commit -s` to sign off your commits to satisfy the DCO check -->
<!-- Ensure your commit messages start with your GitHub issue, e.g., debezium/dbz#<issue_number> -->
Fixes debezium/dbz#2181

## Description
This pull request updates the way environment variables are referenced in the Debezium connector configuration within the `default-server.yaml` file. The change ensures that the variables are not interpolated by SmallRey parser and are instead passed correctly to the runtime environment.

## PR Checklist
<!-- Please review the following checklist and mark items with an 'x' before submitting your pull request. -->
- [X] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [X] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [X] One feature/change per PR unless tightly coupled
- [X] Do a rebase on upstream `main`
