### PR TITLE
Dbz#2168 Improve OTel Metrics Latency

### DIFF
--- a/debezium-operator-api/src/main/java/io/debezium/operator/api/model/runtime/metrics/OtelCollector.java
+++ b/debezium-operator-api/src/main/java/io/debezium/operator/api/model/runtime/metrics/OtelCollector.java
@@ -17,11 +17,33 @@ public class OtelCollector {
     @JsonPropertyDescription("OTLP collector endpoint")
     private String endpoint;
 
+    @JsonPropertyDescription("JMX metrics scrape interval in milliseconds")
+    private int jmxIntervalMs = 10000;
+
+    @JsonPropertyDescription("Metrics export interval in milliseconds")
+    private int metricExportIntervalMs = 60000;
+
     public String getEndpoint() {
         return endpoint;
     }
 
     public void setEndpoint(String endpoint) {
         this.endpoint = endpoint;
+    }
+
+    public int getJmxIntervalMs() {
+        return jmxIntervalMs;
+    }
+
+    public void setJmxIntervalMs(int jmxIntervalMs) {
+        this.jmxIntervalMs = jmxIntervalMs;
+    }
+
+    public int getMetricExportIntervalMs() {
+        return metricExportIntervalMs;
+    }
+
+    public void setMetricExportIntervalMs(int metricExportIntervalMs) {
+        this.metricExportIntervalMs = metricExportIntervalMs;
     }
 }

--- a/debezium-operator-api/src/main/java/io/debezium/operator/api/model/runtime/metrics/OtelCollector.java
+++ b/debezium-operator-api/src/main/java/io/debezium/operator/api/model/runtime/metrics/OtelCollector.java
@@ -17,9 +17,11 @@ public class OtelCollector {
     @JsonPropertyDescription("OTLP collector endpoint")
     private String endpoint;
 
+    @Documented.Field(defaultValue = "10000")
     @JsonPropertyDescription("JMX metrics scrape interval in milliseconds")
     private int jmxIntervalMs = 10000;
 
+    @Documented.Field(defaultValue = "60000")
     @JsonPropertyDescription("Metrics export interval in milliseconds")
     private int metricExportIntervalMs = 60000;
 

--- a/debezium-operator-core/src/main/java/io/debezium/operator/core/dependent/DeploymentDependent.java
+++ b/debezium-operator-core/src/main/java/io/debezium/operator/core/dependent/DeploymentDependent.java
@@ -82,6 +82,8 @@ public class DeploymentDependent extends CRUDKubernetesDependentResource<Deploym
     public static final String OTEL_SERVICE_NAME_ENV = "OTEL_SERVICE_NAME";
     public static final String OTEL_RESOURCE_ATTRIBUTES_ENV = "OTEL_RESOURCE_ATTRIBUTES";
     public static final String OTEL_JMX_CONFIG_ENV = "OTEL_JMX_CONFIG";
+    public static final String OTEL_JMX_INTERVAL_ENV = "OTEL_JMX_INTERVAL_MILLISECONDS";
+    public static final String OTEL_METRIC_EXPORT_INTERVAL_ENV = "OTEL_METRIC_EXPORT_INTERVAL";
     public static final String OTEL_RESOURCE_ATTRIBUTES_FORMAT = "service.name=%s,debezium.connector.type=%s";
     private static final String CONFIG_MD5_ANNOTATION = "debezium.io/server-config-md5";
 
@@ -537,6 +539,8 @@ public class DeploymentDependent extends CRUDKubernetesDependentResource<Deploym
         addEnvVarIfAbsent(container, OTEL_SERVICE_NAME_ENV, name);
         addEnvVarIfAbsent(container, OTEL_RESOURCE_ATTRIBUTES_ENV, resourceAttributes);
         addEnvVarIfAbsent(container, OTEL_JMX_CONFIG_ENV, DEFAULT_OTEL_JMX_CONFIG);
+        addEnvVarIfAbsent(container, OTEL_JMX_INTERVAL_ENV, String.valueOf(otel.getCollector().getJmxIntervalMs()));
+        addEnvVarIfAbsent(container, OTEL_METRIC_EXPORT_INTERVAL_ENV, String.valueOf(otel.getCollector().getMetricExportIntervalMs()));
     }
 
     private void addEnvVarIfAbsent(Container container, String name, String value) {

--- a/debezium-operator-core/src/test/java/io/debezium/operator/core/OpenTelemetryReconcilerTest.java
+++ b/debezium-operator-core/src/test/java/io/debezium/operator/core/OpenTelemetryReconcilerTest.java
@@ -60,7 +60,8 @@ public class OpenTelemetryReconcilerTest {
             final var container = deployment.getSpec().getTemplate().getSpec().getContainers().get(0);
             assertThat(container.getEnv())
                     .extracting(EnvVar::getName)
-                    .doesNotContain("OTEL_ENABLED", "OTEL_SDK_DISABLED", "OTEL_SERVICE_NAME");
+                    .doesNotContain("OTEL_ENABLED", "OTEL_SDK_DISABLED", "OTEL_SERVICE_NAME",
+                            "OTEL_JMX_INTERVAL_MILLISECONDS", "OTEL_METRIC_EXPORT_INTERVAL");
         });
     }
 
@@ -90,6 +91,10 @@ public class OpenTelemetryReconcilerTest {
             assertThat(envVars).anyMatch(e -> "OTEL_RESOURCE_ATTRIBUTES".equals(e.getName())
                     && e.getValue().contains("service.name=" + DS_NAME)
                     && e.getValue().contains("debezium.connector.type=postgresql"));
+            assertThat(envVars).anyMatch(e -> "OTEL_JMX_INTERVAL_MILLISECONDS".equals(e.getName())
+                    && "10000".equals(e.getValue()));
+            assertThat(envVars).anyMatch(e -> "OTEL_METRIC_EXPORT_INTERVAL".equals(e.getName())
+                    && "60000".equals(e.getValue()));
         });
     }
 
@@ -113,6 +118,33 @@ public class OpenTelemetryReconcilerTest {
             assertThat(container.getEnv())
                     .anyMatch(e -> "OTEL_EXPORTER_OTLP_ENDPOINT".equals(e.getName())
                             && "http://my-collector:4317".equals(e.getValue()));
+        });
+    }
+
+    @Test
+    void shouldUseCustomIntervalsWhenProvided() {
+        var otel = debeziumServer.getSpec().getRuntime().getMetrics().getOpenTelemetry();
+        otel.setEnabled(true);
+        otel.setCollector(new OtelCollectorBuilder()
+                .withJmxIntervalMs(1000)
+                .withMetricExportIntervalMs(5000)
+                .build());
+
+        client.resource(debeziumServer).create();
+        await().ignoreException(NullPointerException.class).atMost(2, TimeUnit.MINUTES).untilAsserted(() -> {
+            final var deployment = client.apps().deployments()
+                    .inNamespace(debeziumServer.getMetadata().getNamespace())
+                    .withName(DS_NAME)
+                    .get();
+            assertThat(deployment).isNotNull();
+
+            final var container = deployment.getSpec().getTemplate().getSpec().getContainers().get(0);
+            assertThat(container.getEnv())
+                    .anyMatch(e -> "OTEL_JMX_INTERVAL_MILLISECONDS".equals(e.getName())
+                            && "1000".equals(e.getValue()));
+            assertThat(container.getEnv())
+                    .anyMatch(e -> "OTEL_METRIC_EXPORT_INTERVAL".equals(e.getName())
+                            && "5000".equals(e.getValue()));
         });
     }
 }

--- a/debezium-operator-dist/src/main/examples/postgres/010_debezium-server-ephemeral.yml
+++ b/debezium-operator-dist/src/main/examples/postgres/010_debezium-server-ephemeral.yml
@@ -27,8 +27,8 @@ spec:
     config:
       database.hostname: postgresql
       database.port: 5432
-      database.user: ${POSTGRES_USER}
-      database.password: ${POSTGRES_PASSWORD}
-      database.dbname: ${POSTGRES_DB}
+      database.user: $${POSTGRES_USER}
+      database.password: $${POSTGRES_PASSWORD}
+      database.dbname: $${POSTGRES_DB}
       topic.prefix: inventory
       schema.include.list: inventory

--- a/docs/reference.adoc
+++ b/docs/reference.adoc
@@ -415,6 +415,8 @@ Used in: <<debezium-operator-schema-reference-opentelemetry, `+OpenTelemetry+`>>
 |===
 | Property | Type | Default | Description
 | [[debezium-operator-schema-reference-otelcollector-endpoint]]<<debezium-operator-schema-reference-otelcollector-endpoint, `+endpoint+`>> | String |  | OTLP collector endpoint
+| [[debezium-operator-schema-reference-otelcollector-jmxintervalms]]<<debezium-operator-schema-reference-otelcollector-jmxintervalms, `+jmxIntervalMs+`>> | int |  | JMX metrics scrape interval in milliseconds
+| [[debezium-operator-schema-reference-otelcollector-metricexportintervalms]]<<debezium-operator-schema-reference-otelcollector-metricexportintervalms, `+metricExportIntervalMs+`>> | int |  | Metrics export interval in milliseconds
 |===
 
 [#debezium-operator-schema-reference-podtemplate]

--- a/docs/reference.adoc
+++ b/docs/reference.adoc
@@ -415,8 +415,8 @@ Used in: <<debezium-operator-schema-reference-opentelemetry, `+OpenTelemetry+`>>
 |===
 | Property | Type | Default | Description
 | [[debezium-operator-schema-reference-otelcollector-endpoint]]<<debezium-operator-schema-reference-otelcollector-endpoint, `+endpoint+`>> | String |  | OTLP collector endpoint
-| [[debezium-operator-schema-reference-otelcollector-jmxintervalms]]<<debezium-operator-schema-reference-otelcollector-jmxintervalms, `+jmxIntervalMs+`>> | int |  | JMX metrics scrape interval in milliseconds
-| [[debezium-operator-schema-reference-otelcollector-metricexportintervalms]]<<debezium-operator-schema-reference-otelcollector-metricexportintervalms, `+metricExportIntervalMs+`>> | int |  | Metrics export interval in milliseconds
+| [[debezium-operator-schema-reference-otelcollector-jmxintervalms]]<<debezium-operator-schema-reference-otelcollector-jmxintervalms, `+jmxIntervalMs+`>> | int | 10000 | JMX metrics scrape interval in milliseconds
+| [[debezium-operator-schema-reference-otelcollector-metricexportintervalms]]<<debezium-operator-schema-reference-otelcollector-metricexportintervalms, `+metricExportIntervalMs+`>> | int | 60000 | Metrics export interval in milliseconds
 |===
 
 [#debezium-operator-schema-reference-podtemplate]

--- a/k8/debeziumservers.debezium.io-v1.yml
+++ b/k8/debeziumservers.debezium.io-v1.yml
@@ -204,6 +204,12 @@ spec:
                               endpoint:
                                 description: "OTLP collector endpoint"
                                 type: "string"
+                              jmxIntervalMs:
+                                description: "JMX metrics scrape interval in milliseconds"
+                                type: "integer"
+                              metricExportIntervalMs:
+                                description: "Metrics export interval in milliseconds"
+                                type: "integer"
                             type: "object"
                           enabled:
                             description: "Enables OpenTelemetry"

--- a/k8/kubernetes.yml
+++ b/k8/kubernetes.yml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   annotations:
-    app.quarkus.io/quarkus-version: 3.36.0
+    app.quarkus.io/quarkus-version: 3.36.3
   labels:
     app.kubernetes.io/name: debezium-operator
     app.kubernetes.io/managed-by: quarkus
@@ -158,7 +158,7 @@ apiVersion: v1
 kind: Service
 metadata:
   annotations:
-    app.quarkus.io/quarkus-version: 3.36.0
+    app.quarkus.io/quarkus-version: 3.36.3
   labels:
     app.kubernetes.io/name: debezium-operator
     app.kubernetes.io/managed-by: quarkus
@@ -177,7 +177,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    app.quarkus.io/quarkus-version: 3.36.0
+    app.quarkus.io/quarkus-version: 3.36.3
   labels:
     app.kubernetes.io/name: debezium-operator
     app.kubernetes.io/managed-by: quarkus
@@ -190,7 +190,7 @@ spec:
   template:
     metadata:
       annotations:
-        app.quarkus.io/quarkus-version: 3.36.0
+        app.quarkus.io/quarkus-version: 3.36.3
       labels:
         app.kubernetes.io/managed-by: quarkus
         app.kubernetes.io/name: debezium-operator
@@ -203,6 +203,32 @@ spec:
                   fieldPath: metadata.namespace
             - name: QUARKUS_OPERATOR_SDK_CONTROLLERS_DEBEZIUMSERVER_NAMESPACES
               value: JOSDK_WATCH_CURRENT
+            - name: QUARKUS_OTEL_EXPORTER_OTLP_ENDPOINT
+              value: http://otel-collector:4317
+            - name: QUARKUS_OTEL_K8S_RESOURCE_CONTAINER_NAME
+              value: debezium-operator
+            - name: QUARKUS_OTEL_K8S_RESOURCE_DEPLOYMENT_NAME
+              value: debezium-operator
+            - name: QUARKUS_OTEL_K8S_RESOURCE_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: QUARKUS_OTEL_K8S_RESOURCE_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: QUARKUS_OTEL_K8S_RESOURCE_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: QUARKUS_OTEL_K8S_RESOURCE_POD_UID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.uid
+            - name: QUARKUS_OTEL_METRIC_EXPORT_INTERVAL
+              value: "60000"
+            - name: QUARKUS_OTEL_RESOURCE_ATTRIBUTES
+              value: service.name=debezium-operator
           image: quay.io/debezium/operator:nightly
           imagePullPolicy: Always
           livenessProbe:


### PR DESCRIPTION
<!-- Make sure all your commits are signed before submitting your pull request -->
<!-- Run `git commit -s` to sign off your commits to satisfy the DCO check -->
<!-- Ensure your commit messages start with your GitHub issue, e.g., debezium/dbz#<issue_number> -->
Fixes debezium/dbz#2168

## Description
This pull request introduces enhanced configuration options for OpenTelemetry metrics collection in the Debezium Operator, particularly allowing customization of JMX scrape and metrics export intervals. It also updates deployment manifests, documentation, and tests to support and validate these new options. Additionally, environment variable substitution syntax in example YAML files is standardized, and the Quarkus version annotation is updated.

## PR Checklist
<!-- Please review the following checklist and mark items with an 'x' before submitting your pull request. -->
- [X] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [X] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [X] One feature/change per PR unless tightly coupled
- [X] Do a rebase on upstream `main`
