### PR TITLE
debezium/dbz#2251 Support priorityClassName in pod template

### DIFF
--- a/debezium-operator-api/src/main/java/io/debezium/operator/api/model/runtime/templates/PodTemplate.java
+++ b/debezium-operator-api/src/main/java/io/debezium/operator/api/model/runtime/templates/PodTemplate.java
@@ -19,7 +19,7 @@ import io.fabric8.kubernetes.api.model.LocalObjectReference;
 import io.fabric8.kubernetes.api.model.PodSecurityContext;
 import io.fabric8.kubernetes.api.model.Toleration;
 
-@JsonPropertyOrder({ "metadata", "imagePullSecrets", "affinity", "nodeSelector", "tolerations" })
+@JsonPropertyOrder({ "metadata", "imagePullSecrets", "affinity", "nodeSelector", "tolerations", "priorityClassName" })
 @JsonInclude(JsonInclude.Include.NON_DEFAULT)
 @Documented
 public class PodTemplate implements HasMetadataTemplate, Serializable {
@@ -52,6 +52,10 @@ public class PodTemplate implements HasMetadataTemplate, Serializable {
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     @Documented.Field(k8Ref = "toleration-v1-core")
     private List<Toleration> tolerations = List.of();
+
+    @JsonPropertyDescription("Name of the priority class used to assign a priority to the pod.")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private String priorityClassName;
 
     @Override
     public MetadataTemplate getMetadata() {
@@ -101,5 +105,13 @@ public class PodTemplate implements HasMetadataTemplate, Serializable {
 
     public void setTolerations(List<Toleration> tolerations) {
         this.tolerations = tolerations;
+    }
+
+    public String getPriorityClassName() {
+        return priorityClassName;
+    }
+
+    public void setPriorityClassName(String priorityClassName) {
+        this.priorityClassName = priorityClassName;
     }
 }

--- a/debezium-operator-api/src/main/java/io/debezium/operator/api/model/runtime/templates/PodTemplate.java
+++ b/debezium-operator-api/src/main/java/io/debezium/operator/api/model/runtime/templates/PodTemplate.java
@@ -55,6 +55,7 @@ public class PodTemplate implements HasMetadataTemplate, Serializable {
 
     @JsonPropertyDescription("Name of the priority class used to assign a priority to the pod.")
     @JsonInclude(JsonInclude.Include.NON_NULL)
+    @Documented.Field(type = "String", k8Ref = "priorityclass-v1-scheduling-k8s-io")
     private String priorityClassName;
 
     @Override

--- a/debezium-operator-core/src/main/java/io/debezium/operator/core/dependent/DeploymentDependent.java
+++ b/debezium-operator-core/src/main/java/io/debezium/operator/core/dependent/DeploymentDependent.java
@@ -204,6 +204,7 @@ public class DeploymentDependent extends CRUDKubernetesDependentResource<Deploym
         podSpec.setImagePullSecrets(template.getImagePullSecrets());
         podSpec.setNodeSelector(template.getNodeSelector());
         podSpec.setTolerations(template.getTolerations());
+        podSpec.setPriorityClassName(template.getPriorityClassName());
         podMeta.getLabels().putAll(templateMeta.getLabels());
         podMeta.getAnnotations().putAll(templateMeta.getAnnotations());
     }

--- a/docs/reference.adoc
+++ b/docs/reference.adoc
@@ -434,6 +434,7 @@ Used in: <<debezium-operator-schema-reference-templates, `+Templates+`>>
 | [[debezium-operator-schema-reference-podtemplate-securitycontext]]<<debezium-operator-schema-reference-podtemplate-securitycontext, `+securityContext+`>> | https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#podsecuritycontext-v1-core[`+PodSecurityContext+`] |  | Pod-level security attributes and container settings
 | [[debezium-operator-schema-reference-podtemplate-nodeselector]]<<debezium-operator-schema-reference-podtemplate-nodeselector, `+nodeSelector+`>> | Map<String, String> |  | NodeSelector is a selector which must be true for the pod to fit on a node.
 | [[debezium-operator-schema-reference-podtemplate-tolerations]]<<debezium-operator-schema-reference-podtemplate-tolerations, `+tolerations+`>> | https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#toleration-v1-core[`+List<Toleration>+`] |  | Tolerations applied to the pod to allow scheduling on tainted nodes.
+| [[debezium-operator-schema-reference-podtemplate-priorityclassname]]<<debezium-operator-schema-reference-podtemplate-priorityclassname, `+priorityClassName+`>> | String |  | Name of the priority class used to assign a priority to the pod.
 |===
 
 [#debezium-operator-schema-reference-predicate]

--- a/docs/reference.adoc
+++ b/docs/reference.adoc
@@ -434,7 +434,7 @@ Used in: <<debezium-operator-schema-reference-templates, `+Templates+`>>
 | [[debezium-operator-schema-reference-podtemplate-securitycontext]]<<debezium-operator-schema-reference-podtemplate-securitycontext, `+securityContext+`>> | https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#podsecuritycontext-v1-core[`+PodSecurityContext+`] |  | Pod-level security attributes and container settings
 | [[debezium-operator-schema-reference-podtemplate-nodeselector]]<<debezium-operator-schema-reference-podtemplate-nodeselector, `+nodeSelector+`>> | Map<String, String> |  | NodeSelector is a selector which must be true for the pod to fit on a node.
 | [[debezium-operator-schema-reference-podtemplate-tolerations]]<<debezium-operator-schema-reference-podtemplate-tolerations, `+tolerations+`>> | https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#toleration-v1-core[`+List<Toleration>+`] |  | Tolerations applied to the pod to allow scheduling on tainted nodes.
-| [[debezium-operator-schema-reference-podtemplate-priorityclassname]]<<debezium-operator-schema-reference-podtemplate-priorityclassname, `+priorityClassName+`>> | String |  | Name of the priority class used to assign a priority to the pod.
+| [[debezium-operator-schema-reference-podtemplate-priorityclassname]]<<debezium-operator-schema-reference-podtemplate-priorityclassname, `+priorityClassName+`>> | https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#priorityclass-v1-scheduling-k8s-io[`+String+`] |  | Name of the priority class used to assign a priority to the pod.
 |===
 
 [#debezium-operator-schema-reference-predicate]

--- a/k8/debeziumservers.debezium.io-v1.yml
+++ b/k8/debeziumservers.debezium.io-v1.yml
@@ -1464,6 +1464,10 @@ spec:
                             description: "NodeSelector is a selector which must be\
                               \ true for the pod to fit on a node."
                             type: "object"
+                          priorityClassName:
+                            description: "Name of the priority class used to assign\
+                              \ a priority to the pod."
+                            type: "string"
                           securityContext:
                             description: "Pod-level security attributes and container\
                               \ settings"


### PR DESCRIPTION
Fixes debezium/dbz#2251

## Description
Adds `priorityClassName` to the `DebeziumServer` pod template and passes it through to the deployment's pod spec. CRD and reference docs regenerated.

## PR Checklist
- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`