### PR TITLE
debezium/dbz#2461 Add image pull secrets support to the operator Helm

### DIFF
--- a/debezium-operator-core/src/main/helm/values.yaml
+++ b/debezium-operator-core/src/main/helm/values.yaml
@@ -1,0 +1,2 @@
+app:
+  imagePullSecrets: []

--- a/debezium-operator-core/src/main/resources/application.properties
+++ b/debezium-operator-core/src/main/resources/application.properties
@@ -1,6 +1,12 @@
 debezium.server.image.name=quay.io/debezium/server
 quarkus.application.name=debezium-operator
 
+# Image pull secrets for the operator deployment, parametrized in the Helm chart only.
+quarkus.helm.expressions.0.path=(kind == Deployment).spec.template.spec.serviceAccountName
+quarkus.helm.expressions.0.expression=debezium-operator\n      {{- with .Values.app.imagePullSecrets }}\n      imagePullSecrets:\n        {{- toYaml . | nindent 8 }}\n      {{- end }}
+quarkus.helm.values-schema.properties."app.imagePullSecrets".description=Image pull secrets used for pulling the operator image from private registries
+quarkus.helm.values-schema.properties."app.imagePullSecrets".type=array
+
 
 # Quarkus helm configurations
 quarkus.helm.values."app.envs.QUARKUS_OPERATOR_SDK_CONTROLLERS_DEBEZIUMSERVER_NAMESPACES".value=JOSDK_ALL_NAMESPACES


### PR DESCRIPTION
<!-- Make sure all your commits are signed before submitting your pull request -->
<!-- Run `git commit -s` to sign off your commits to satisfy the DCO check -->
<!-- Ensure your commit messages start with your GitHub issue, e.g., debezium/dbz#<issue_number> -->
Fixes debezium/dbz#2461

## Description
The generated `debezium-operator` Helm chart offers no way to configure image
pull secrets for the operator Deployment.

This PR adds an `app.imagePullSecrets` chart value:

```yaml
app:
  imagePullSecrets:
    - name: my-registry-secret
```
The generated deployment template gains:
```yaml
      serviceAccountName: debezium-operator
      {{- with .Values.app.imagePullSecrets }}
      imagePullSecrets:
        {{- toYaml . | nindent 8 }}
      {{- end }}
```

## PR Checklist
<!-- Please review the following checklist and mark items with an 'x' before submitting your pull request. -->
- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`