### PR TITLE
dbz#2528 Stop annotation (debezium.io/stop) does not trigger reconciliation

### DIFF
--- a/debezium-operator-core/pom.xml
+++ b/debezium-operator-core/pom.xml
@@ -67,6 +67,13 @@
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.debezium</groupId>
+            <artifactId>debezium-util</artifactId>
+            <version>${version.debezium}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/debezium-operator-core/src/main/java/io/debezium/operator/core/DebeziumServerReconciler.java
+++ b/debezium-operator-core/src/main/java/io/debezium/operator/core/DebeziumServerReconciler.java
@@ -51,7 +51,7 @@ import io.quarkiverse.operatorsdk.annotations.RBACRule;
 import io.quarkiverse.operatorsdk.annotations.RBACVerbs;
 import io.quarkus.logging.Log;
 
-@ControllerConfiguration(name = "debeziumserver", informer = @Informer(namespaces = Constants.WATCH_CURRENT_NAMESPACE))
+@ControllerConfiguration(name = "debeziumserver", generationAwareEventProcessing = false, informer = @Informer(namespaces = Constants.WATCH_CURRENT_NAMESPACE, onUpdateFilter = DebeziumServerUpdateFilter.class))
 @Workflow(dependents = {
         @Dependent(name = "service-account", type = ServiceAccountDependent.class, reconcilePrecondition = CreateServiceAccount.class),
         @Dependent(name = "pvc", type = PvcDependent.class, reconcilePrecondition = CreatePvc.class),

--- a/debezium-operator-core/src/main/java/io/debezium/operator/core/DebeziumServerUpdateFilter.java
+++ b/debezium-operator-core/src/main/java/io/debezium/operator/core/DebeziumServerUpdateFilter.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.operator.core;
+
+import java.util.Objects;
+
+import io.debezium.operator.api.model.DebeziumServer;
+import io.javaoperatorsdk.operator.processing.event.source.filter.OnUpdateFilter;
+
+/**
+ * Filters {@link DebeziumServer} update events reaching the reconciler.
+ * <p>
+ * The controller disables {@code generationAwareEventProcessing} so that changes to the
+ * {@code debezium.io/stop} annotation (which live in {@code metadata} and therefore never bump
+ * {@code metadata.generation}) can trigger reconciliation. To retain the benefits of
+ * generation-aware processing, this filter accepts an update only when the generation changed
+ * (i.e. a real spec change) or when the stop flag was toggled. In particular, it rejects the
+ * operator's own status patches, preventing reconciliation loops.
+ */
+public class DebeziumServerUpdateFilter implements OnUpdateFilter<DebeziumServer> {
+
+    @Override
+    public boolean accept(DebeziumServer newResource, DebeziumServer oldResource) {
+        return generationChanged(newResource, oldResource)
+                || newResource.isStopped() != oldResource.isStopped();
+    }
+
+    private static boolean generationChanged(DebeziumServer newResource, DebeziumServer oldResource) {
+        return !Objects.equals(newResource.getMetadata().getGeneration(), oldResource.getMetadata().getGeneration());
+    }
+}

--- a/debezium-operator-core/src/main/java/io/debezium/operator/core/dependent/conditions/DeploymentReady.java
+++ b/debezium-operator-core/src/main/java/io/debezium/operator/core/dependent/conditions/DeploymentReady.java
@@ -5,10 +5,9 @@
  */
 package io.debezium.operator.core.dependent.conditions;
 
-import java.util.Objects;
-
 import io.debezium.operator.api.model.DebeziumServer;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
+import io.fabric8.kubernetes.api.model.apps.DeploymentStatus;
 import io.javaoperatorsdk.operator.api.reconciler.Context;
 import io.javaoperatorsdk.operator.api.reconciler.dependent.DependentResource;
 import io.javaoperatorsdk.operator.processing.dependent.workflow.Condition;
@@ -20,9 +19,29 @@ public class DeploymentReady implements Condition<Deployment, DebeziumServer> {
                          DebeziumServer primary,
                          Context<DebeziumServer> context) {
         return dependentResource.getSecondaryResource(primary, context)
-                .map(deployment -> Objects.equals(
-                        deployment.getSpec().getReplicas(),
-                        deployment.getStatus().getReadyReplicas()))
+                .map(DeploymentReady::isReady)
                 .orElse(false);
+    }
+
+    private static boolean isReady(Deployment deployment) {
+        // The deployment is ready when the ready replicas match the desired count. A stopped
+        // server is scaled to 0 replicas; Kubernetes then omits readyReplicas from the status,
+        // so it must be read as 0 (see readyReplicas) for 0 == 0 to hold (dbz#2528).
+        return desiredReplicas(deployment) == readyReplicas(deployment);
+    }
+
+    private static int desiredReplicas(Deployment deployment) {
+        var replicas = deployment.getSpec().getReplicas();
+        return replicas == null ? 0 : replicas;
+    }
+
+    private static int readyReplicas(Deployment deployment) {
+        // Kubernetes omits readyReplicas from the status when it is 0 (e.g. a stopped
+        // server scaled to 0 replicas), so a null value must be treated as 0.
+        DeploymentStatus status = deployment.getStatus();
+        if (status == null || status.getReadyReplicas() == null) {
+            return 0;
+        }
+        return status.getReadyReplicas();
     }
 }

--- a/debezium-operator-core/src/test/java/io/debezium/operator/core/DebeziumServerUpdateFilterTest.java
+++ b/debezium-operator-core/src/test/java/io/debezium/operator/core/DebeziumServerUpdateFilterTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.operator.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import io.debezium.doc.FixFor;
+import io.debezium.operator.api.model.DebeziumServer;
+import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
+
+class DebeziumServerUpdateFilterTest {
+
+    private final DebeziumServerUpdateFilter filter = new DebeziumServerUpdateFilter();
+
+    private static DebeziumServer server(long generation, boolean stopped) {
+        var server = new DebeziumServer();
+        var metadata = new ObjectMetaBuilder()
+                .withName("test-ds")
+                .withGeneration(generation)
+                .withAnnotations(stopped ? Map.of("debezium.io/stop", "true") : Map.of())
+                .build();
+        server.setMetadata(metadata);
+        return server;
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2528")
+    void shouldAcceptWhenGenerationChanged() {
+        assertThat(filter.accept(server(2, false), server(1, false))).isTrue();
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2528")
+    void shouldAcceptWhenStopAnnotationAdded() {
+        assertThat(filter.accept(server(1, true), server(1, false))).isTrue();
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2528")
+    void shouldAcceptWhenStopAnnotationRemoved() {
+        assertThat(filter.accept(server(1, false), server(1, true))).isTrue();
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2528")
+    void shouldRejectWhenNothingRelevantChanged() {
+        assertThat(filter.accept(server(1, false), server(1, false))).isFalse();
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2528")
+    void shouldRejectWhenOnlyStatusChangedWhileStopped() {
+        // Same generation and same stop flag: e.g. the operator's own status patch must not
+        // re-trigger reconciliation, avoiding a loop.
+        assertThat(filter.accept(server(1, true), server(1, true))).isFalse();
+    }
+}

--- a/debezium-operator-core/src/test/java/io/debezium/operator/core/dependent/conditions/DeploymentReadyTest.java
+++ b/debezium-operator-core/src/test/java/io/debezium/operator/core/dependent/conditions/DeploymentReadyTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.operator.core.dependent.conditions;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+
+import io.debezium.doc.FixFor;
+import io.debezium.operator.api.model.DebeziumServer;
+import io.fabric8.kubernetes.api.model.apps.Deployment;
+import io.fabric8.kubernetes.api.model.apps.DeploymentBuilder;
+import io.javaoperatorsdk.operator.api.reconciler.Context;
+import io.javaoperatorsdk.operator.api.reconciler.dependent.DependentResource;
+import io.javaoperatorsdk.operator.api.reconciler.dependent.ReconcileResult;
+
+class DeploymentReadyTest {
+
+    private final DeploymentReady condition = new DeploymentReady();
+
+    @Test
+    @FixFor("debezium/dbz#2528")
+    void shouldBeMetWhenStoppedAndReadyReplicasOmitted() {
+        // A stopped server is scaled to 0 replicas; Kubernetes then omits readyReplicas
+        // from the status, which must be interpreted as 0.
+        var deployment = new DeploymentBuilder()
+                .withNewSpec().withReplicas(0).endSpec()
+                .withNewStatus().endStatus()
+                .build();
+        assertThat(condition.isMet(dependentReturning(deployment), null, null)).isTrue();
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2528")
+    void shouldBeMetWhenRunningAndReadyReplicasMatch() {
+        var deployment = new DeploymentBuilder()
+                .withNewSpec().withReplicas(1).endSpec()
+                .withNewStatus().withReadyReplicas(1).endStatus()
+                .build();
+        assertThat(condition.isMet(dependentReturning(deployment), null, null)).isTrue();
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2528")
+    void shouldNotBeMetWhenRunningButReadyReplicasOmitted() {
+        var deployment = new DeploymentBuilder()
+                .withNewSpec().withReplicas(1).endSpec()
+                .withNewStatus().endStatus()
+                .build();
+        assertThat(condition.isMet(dependentReturning(deployment), null, null)).isFalse();
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2528")
+    void shouldNotBeMetWhenSecondaryResourceMissing() {
+        assertThat(condition.isMet(dependentReturning(null), null, null)).isFalse();
+    }
+
+    private static DependentResource<Deployment, DebeziumServer> dependentReturning(Deployment deployment) {
+        return new DependentResource<>() {
+            @Override
+            public Optional<Deployment> getSecondaryResource(DebeziumServer primary, Context<DebeziumServer> context) {
+                return Optional.ofNullable(deployment);
+            }
+
+            @Override
+            public ReconcileResult<Deployment> reconcile(DebeziumServer primary, Context<DebeziumServer> context) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public Class<Deployment> resourceType() {
+                return Deployment.class;
+            }
+        };
+    }
+}

--- a/systemtests/pom.xml
+++ b/systemtests/pom.xml
@@ -123,6 +123,13 @@
             <version>${version.debezium}</version>
         </dependency>
         <dependency>
+            <groupId>io.debezium</groupId>
+            <artifactId>debezium-util</artifactId>
+            <version>${version.debezium}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>io.skodjob</groupId>
             <artifactId>database-manipulation-tool-schema</artifactId>
             <version>${dmt.version}</version>

--- a/systemtests/src/test/java/io/debezium/operator/systemtests/StopAnnotationTest.java
+++ b/systemtests/src/test/java/io/debezium/operator/systemtests/StopAnnotationTest.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.operator.systemtests;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import java.time.Duration;
+import java.util.HashMap;
+
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.debezium.doc.FixFor;
+import io.debezium.operator.api.model.DebeziumServer;
+import io.debezium.operator.api.model.status.Condition;
+import io.debezium.operator.systemtests.resources.NamespaceHolder;
+import io.debezium.operator.systemtests.resources.operator.DebeziumOperatorBundleResource;
+import io.debezium.operator.systemtests.resources.server.DebeziumServerGenerator;
+import io.debezium.operator.systemtests.resources.server.DebeziumServerResource;
+import io.fabric8.kubernetes.api.model.apps.Deployment;
+import io.skodjob.kubetest4j.resources.KubeResourceManager;
+
+public class StopAnnotationTest extends TestBase {
+    private final Logger logger = LoggerFactory.getLogger(this.getClass());
+
+    @Test
+    @FixFor("debezium/dbz#2528")
+    void testStopAnnotationStopsAndResumesServer() {
+        String namespace = NamespaceHolder.INSTANCE.getCurrentNamespace();
+        DebeziumOperatorBundleResource operatorBundleResource = new DebeziumOperatorBundleResource();
+        operatorBundleResource.configureAsDefault(namespace);
+        logger.info("Deploying Operator");
+        operatorBundleResource.deploy();
+
+        DebeziumServer server = DebeziumServerGenerator.generateDefaultMysqlToRedis(namespace);
+        String name = server.getMetadata().getName();
+
+        logger.info("Deploying Debezium Server");
+        KubeResourceManager.get().createResourceWithWait(server);
+        assertStreamingWorks();
+        assertThat(deploymentReplicas(namespace, name)).isEqualTo(1);
+
+        // Stop the server by adding the debezium.io/stop annotation.
+        logger.info("Stopping Debezium Server via debezium.io/stop annotation");
+        if (server.getMetadata().getAnnotations() == null) {
+            server.getMetadata().setAnnotations(new HashMap<>());
+        }
+        server.setStopped(true);
+        KubeResourceManager.get().createOrUpdateResourceWithWait(server);
+
+        // The Ready condition stays True while stopped (0 == 0 replicas ready), so we must poll
+        // the Deployment replicas and the Running condition to observe that reconciliation
+        // actually scaled the server down.
+        await().atMost(Duration.ofMinutes(2)).pollInterval(Duration.ofSeconds(5)).untilAsserted(() -> {
+            assertThat(deploymentReplicas(namespace, name)).isEqualTo(0);
+            Condition running = runningCondition(namespace, name);
+            assertThat(running).isNotNull();
+            assertThat(running.getStatus()).isEqualTo("False");
+            assertThat(running.getMessage()).isEqualTo("Server %s is stopped".formatted(name));
+        });
+
+        // The stopped state must be stable. Once scaled to 0 replicas, Kubernetes omits
+        // readyReplicas from the Deployment status; if that omitted value were not read as 0
+        // (the dbz#2528 bug), the server would never be reported ready and would flip to
+        // "deployment in progress". Assert the stopped, ready condition holds continuously so
+        // that such a regression fails the test instead of passing on the first good poll.
+        await().during(Duration.ofSeconds(45)).atMost(Duration.ofSeconds(75)).pollInterval(Duration.ofSeconds(5)).untilAsserted(() -> {
+            assertThat(deploymentReplicas(namespace, name)).isEqualTo(0);
+            Condition running = runningCondition(namespace, name);
+            assertThat(running).isNotNull();
+            assertThat(running.getStatus()).isEqualTo("False");
+            assertThat(running.getMessage()).isEqualTo("Server %s is stopped".formatted(name));
+            Condition ready = readyCondition(namespace, name);
+            assertThat(ready).isNotNull();
+            assertThat(ready.getStatus()).isEqualTo("True");
+        });
+
+        // Resume the server by removing the annotation.
+        logger.info("Resuming Debezium Server by removing debezium.io/stop annotation");
+        server.setStopped(false);
+        KubeResourceManager.get().createOrUpdateResourceWithWait(server);
+
+        await().atMost(Duration.ofMinutes(2)).pollInterval(Duration.ofSeconds(5)).untilAsserted(() -> {
+            assertThat(deploymentReplicas(namespace, name)).isEqualTo(1);
+            Condition running = runningCondition(namespace, name);
+            assertThat(running).isNotNull();
+            assertThat(running.getStatus()).isEqualTo("True");
+        });
+        assertStreamingWorks();
+    }
+
+    private static int deploymentReplicas(String namespace, String name) {
+        Deployment deployment = KubeResourceManager.get().kubeClient().getClient()
+                .apps().deployments()
+                .inNamespace(namespace)
+                .withName(name)
+                .get();
+        if (deployment == null || deployment.getSpec().getReplicas() == null) {
+            return 0;
+        }
+        return deployment.getSpec().getReplicas();
+    }
+
+    private static Condition runningCondition(String namespace, String name) {
+        return conditionOfType(namespace, name, "Running");
+    }
+
+    private static Condition readyCondition(String namespace, String name) {
+        return conditionOfType(namespace, name, "Ready");
+    }
+
+    private static Condition conditionOfType(String namespace, String name, String type) {
+        DebeziumServer server = new DebeziumServerResource().get(namespace, name);
+        if (server == null || server.getStatus() == null || server.getStatus().getConditions() == null) {
+            return null;
+        }
+        return server.getStatus().getConditions().stream()
+                .filter(condition -> condition.getType().equals(type))
+                .findFirst()
+                .orElse(null);
+    }
+}


### PR DESCRIPTION
<!-- Make sure all your commits are signed before submitting your pull request -->
<!-- Run `git commit -s` to sign off your commits to satisfy the DCO check -->
<!-- Ensure your commit messages start with your GitHub issue, e.g., debezium/dbz#<issue_number> -->
Fixes debezium/dbz#2528

## Description
This pull request addresses and fixes an issue with the handling of the `debezium.io/stop` annotation, ensuring that Debezium Server resources are properly reconciled when stopped or resumed, and that deployments with zero replicas are correctly reported as ready. The changes improve the controller’s update filtering, deployment readiness logic, and add thorough unit and system tests to prevent regressions.

## PR Checklist
<!-- Please review the following checklist and mark items with an 'x' before submitting your pull request. -->
- [X] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [X] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [X] One feature/change per PR unless tightly coupled
- [X] Do a rebase on upstream `main`
