### PR TITLE
debezium/dbz#2588 Create the imagePullSecrets Helm value from a Deployment baseline

### DIFF
--- a/debezium-operator-core/src/main/kubernetes/kubernetes.yml
+++ b/debezium-operator-core/src/main/kubernetes/kubernetes.yml
@@ -1,0 +1,23 @@
+---
+# Baseline for the generated Deployment, merged by the Quarkus Kubernetes extension.
+# See https://quarkus.io/guides/deploying-to-kubernetes#using-existing-resources
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  # Must match `quarkus.kubernetes.name`, otherwise a second Deployment is generated.
+  name: debezium-operator
+  # The generated ClusterRole copies the labels of the Deployment at the moment it is created,
+  # which happens before Quarkus adds its own labels to this baseline.
+  # Without this label the ClusterRole would end up with no labels at all.
+  labels:
+    app.kubernetes.io/name: debezium-operator
+spec:
+  template:
+    spec:
+      # quarkus-helm can only turn a field into a Helm value if the field already exists in the generated resource.
+      # An empty list `[]` does not survive the generation,
+      # because the fabric8 model marks `PodSpec.imagePullSecrets` with `@JsonInclude(NON_EMPTY)`.
+      # A list with one null element does survive.
+      # `src/main/helm/values.yaml` replaces the resulting Helm default with a real empty list.
+      # See https://github.com/quarkiverse/quarkus-helm/issues/453
+      imagePullSecrets: [~]

--- a/debezium-operator-core/src/main/resources/application.properties
+++ b/debezium-operator-core/src/main/resources/application.properties
@@ -1,12 +1,16 @@
 debezium.server.image.name=quay.io/debezium/server
 quarkus.application.name=debezium-operator
+# Dekorate only adds this variable to the Deployment it generates itself.
+# The baseline in src/main/kubernetes/kubernetes.yml replaces that Deployment, so the variable is set explicitly.
+quarkus.kubernetes.env.fields.KUBERNETES_NAMESPACE=metadata.namespace
 
 # Image pull secrets for the operator deployment, parametrized in the Helm chart only.
-quarkus.helm.expressions.0.path=(kind == Deployment).spec.template.spec.serviceAccountName
-quarkus.helm.expressions.0.expression=debezium-operator\n      {{- with .Values.app.imagePullSecrets }}\n      imagePullSecrets:\n        {{- toYaml . | nindent 8 }}\n      {{- end }}
+# The field itself comes from src/main/kubernetes/kubernetes.yml, see the comment there.
+quarkus.helm.values.image-pull-secrets.property=imagePullSecrets
+quarkus.helm.values.image-pull-secrets.paths=(kind == Deployment).spec.template.spec.imagePullSecrets
+quarkus.helm.values.image-pull-secrets.expression={{- toYaml (.Values.app.imagePullSecrets | default list) | nindent 8 }}
 quarkus.helm.values-schema.properties."app.imagePullSecrets".description=Image pull secrets used for pulling the operator image from private registries
 quarkus.helm.values-schema.properties."app.imagePullSecrets".type=array
-
 
 # Quarkus helm configurations
 quarkus.helm.values."app.envs.QUARKUS_OPERATOR_SDK_CONTROLLERS_DEBEZIUMSERVER_NAMESPACES".value=JOSDK_ALL_NAMESPACES


### PR DESCRIPTION
Fixes debezium/dbz#2588

## Description

debezium/debezium-operator#219 added the `app.imagePullSecrets` Helm value by anchoring a `quarkus.helm.expressions` entry on `serviceAccountName` and appending a multi-line YAML block to it.
As discussed in https://github.com/debezium/debezium-operator/pull/219#issuecomment-5547613414, that anchor hardcodes the service account name and the indentation, couples `imagePullSecrets` to an unrelated field, and depends on the build platform's line separator.

This PR creates the field in a Deployment baseline instead and maps it with a regular `quarkus.helm.values` entry.
The chart value, its `[]` default, and its schema entry are unchanged.

### Changes

- `debezium-operator-core/src/main/kubernetes/kubernetes.yml` (new): a Deployment baseline with the placeholder `imagePullSecrets: [~]`.
  `quarkus-helm` can only replace a field that already exists in the generated resource (quarkiverse/quarkus-helm#453).
  An empty list `[]` does not survive the generation, because the fabric8 model marks `PodSpec.imagePullSecrets` with `@JsonInclude(NON_EMPTY)`; a list with one null element does.
  `src/main/helm/values.yaml`, which  already exists, replaces the resulting default with a real empty list.
- `debezium-operator-core/src/main/resources/application.properties`:
  - the two `quarkus.helm.expressions.0.*` lines are replaced by a `quarkus.helm.values.image-pull-secrets` entry with the one-line expression `{{- toYaml (.Values.app.imagePullSecrets | default list) | nindent 8 }}`;
  - `quarkus.kubernetes.env.fields.KUBERNETES_NAMESPACE=metadata.namespace` is added, see below.

The same pattern is in production in https://github.com/aboutbits/postgresql-operator since v0.6.0.
aboutbits/postgresql-operator#62 lists the alternatives that were tried and rejected.

### Side effects of a Deployment baseline

A baseline bypasses Dekorate's default Deployment factory.
Two things depend on that factory, and both are compensated in this PR:

- `KUBERNETES_NAMESPACE` is only added by that factory, so the property above sets it explicitly.
  The generated Deployment is unchanged in this respect, and the Helm chart gains no new value.
- The generated ClusterRole copies the labels of the Deployment at the moment Quarkus creates it, which is before Quarkus adds its own labels to the baseline. The baseline therefore carries `app.kubernetes.io/name` itself.
  The `app.kubernetes.io/version` label cannot be expressed there (fragments are not interpolated), so the ClusterRole loses that one label. The Deployment already has no version label because of `quarkus.kubernetes.idempotent=true`.

### Effect on the generated artifacts

Compared with a build of `main`:

- Helm chart: `helm template` renders `imagePullSecrets: []` by default and `- name: <secret>` when set. `helm lint` passes. `values.yaml`, `values.schema.json`, and the chart README are unchanged.
- `k8/kubernetes.yml` and the OLM CSV gain `imagePullSecrets: [{}]`.
  The API server accepts an entry with an empty name (`validateImagePullSecrets` only rejects fields other than `name`), and the kubelet skips such an entry without a warning (`getPullSecretsForPod`, see kubernetes/kubernetes#99454).
- The ClusterRole loses the `app.kubernetes.io/version` label, as explained above.

## PR Checklist
- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`